### PR TITLE
Allow headers to be edited by clicking on them

### DIFF
--- a/app/assets/stylesheets/map/overlays.css.scss
+++ b/app/assets/stylesheets/map/overlays.css.scss
@@ -105,7 +105,8 @@
 
 /* Overlay */
 .overlay.text,
-.overlay.annotation {
+.overlay.annotation,
+.overlay.header {
 
   display: none;
 
@@ -116,7 +117,7 @@
   &.selected.white-box {
     border-color: rgba(#000, .5);
 
-    &.editable .text { 
+    &.editable .text {
       color: #000!important;
     }
 
@@ -130,18 +131,18 @@
     &.selected.border-dark {
       border-color: rgba(#000, .5);
 
-      .hint { 
+      .hint {
         color: #000;
         @include opacity(1);
       }
     }
 
-  .content > .text { 
+  .content > .text {
     font-family: 'Helvetica Neue', Helvetica, sans-serif; font-weight: 400;
     strong { font-weight: 700; }
   }
 
-  &.droid .content > .text { 
+  &.droid .content > .text {
     font-family: 'Droid Sans', serif; font-weight: 400;
     strong { font-weight: 700; }
   }
@@ -151,32 +152,32 @@
     strong { font-weight: 700; }
   }
 
-  &.vollkorn .content > .text { 
+  &.vollkorn .content > .text {
     font-family: 'Vollkorn', serif; font-weight: 400;
     strong { font-weight: 700; }
   }
 
-  &.open_sans .content > .text { 
+  &.open_sans .content > .text {
     font-family: 'Open Sans', sans-serif; font-weight: 400;
     strong { font-weight: 700; }
   }
 
-  &.lato .content > .text { 
+  &.lato .content > .text {
     font-family: 'Lato', sans-serif; font-weight: 400;
     strong { font-weight: 700; }
   }
 
-  &.graduate .content > .text { 
+  &.graduate .content > .text {
     font-family: 'Graduate', sans-serif; font-weight: 400;
     strong { font-weight: 700; }
   }
 
-  &.old_standard_tt .content > .text { 
+  &.old_standard_tt .content > .text {
     font-family: 'Old Standard TT', sans-serif; font-weight: 400;
     strong { font-weight: 700; }
   }
 
-  &.gravitas_one .content > .text { 
+  &.gravitas_one .content > .text {
     font-family: 'Gravitas One', sans-serif; font-weight: 400;
     strong { font-weight: 700; }
   }
@@ -297,7 +298,7 @@
 
   z-index: 4;
 
-  &:hover { 
+  &:hover {
     background:rgba(#333, .7);
   }
 
@@ -311,7 +312,7 @@
     color: #fff;
     @include opacity(.7);
 
-    strong, em, span { 
+    strong, em, span {
       @include inline-block();
       margin-left: 3px;
     }
@@ -413,7 +414,7 @@
         @include opacity(.8);
       }
 
-      .text { 
+      .text {
         font-weight:normal;
       }
     }
@@ -481,11 +482,11 @@
 
   &:hover .edit,
   &:hover .close,
-  &:hover div.dropdown.properties_dropdown { 
+  &:hover div.dropdown.properties_dropdown {
     @include opacity(1);
   }
 
-  div.dropdown.properties_dropdown { 
+  div.dropdown.properties_dropdown {
     @include opacity(0);
     @include simple-transition(opacity, .10s, ease-in-out);
 
@@ -547,15 +548,15 @@
       position:absolute;
       top: 10px;
       right: 8px;
-      width: 0; 
-      height: 0; 
+      width: 0;
+      height: 0;
       border-left: 3px solid transparent;
       border-right: 3px solid transparent;
       border-top: 4px solid #fff;
     }
   }
 
-} 
+}
 
 // .overlay
 .overlay.editable .content {
@@ -588,11 +589,11 @@
 
   .text {
 
-    em, i { font-style: italic; } 
+    em, i { font-style: italic; }
     strong { font-weight: bold; }
     a { color: inherit; text-decoration: underline; }
 
-     @include user-select(none); this breaks safari edition 
+     @include user-select(none); this breaks safari edition
 
     &.text img {
       display:block;
@@ -655,8 +656,8 @@ div.rule {
   @include simple-transition(opacity, .10s, ease-in-out);
 
   &.horizontal {
-    height: 1px; 
-    width: 100%; 
+    height: 1px;
+    width: 100%;
   }
 
 } // .rule
@@ -700,7 +701,7 @@ div.dropdown.properties_dropdown {
           color: #666666;
         }
 
-        &.field { 
+        &.field {
           margin: 0;
           color: #333;
         }

--- a/app/models/overlay/member.rb
+++ b/app/models/overlay/member.rb
@@ -16,7 +16,7 @@ module CartoDB
 
       # There can be at most one of this types per visualization
       UNIQUE_TYPES = [
-          'header', 'search', 'layer_selector', 'share', 'zoom', 'logo', 'loader', 'fullscreen'
+          'search', 'layer_selector', 'share', 'zoom', 'logo', 'loader', 'fullscreen'
       ]
 
       def initialize(attributes={}, repository=Overlay.repository)
@@ -113,4 +113,3 @@ module CartoDB
     class DuplicateOverlayError < StandardError; end
   end
 end
-

--- a/lib/assets/javascripts/cartodb/table/export_image_view.js
+++ b/lib/assets/javascripts/cartodb/table/export_image_view.js
@@ -48,7 +48,7 @@ cdb.admin.ExportImageView = cdb.core.View.extend({
     this.map = this.options.map;
     this.vis = this.options.vis;
     this.mapOverlays = this.options.overlays;
-    this.header = this.mapOverlays.getHeaderOverlay();
+    this.header = this.mapOverlays.getHeaderOverlays();
 
     this.vis.bind("change:name", this._onChangeVisName, this);
     this.vis.bind("change:description", this._onChangeVisDescription, this);
@@ -59,6 +59,10 @@ cdb.admin.ExportImageView = cdb.core.View.extend({
     });
 
     if (this.header) {
+      var self = this;
+      _.each(this.header, function(header) {
+        _.extend(self.options, header.attributes);
+      });
       _.extend(this.options, this.header.attributes);
     }
 

--- a/lib/assets/javascripts/cartodb/table/map/map_options_dropdown.js
+++ b/lib/assets/javascripts/cartodb/table/map/map_options_dropdown.js
@@ -21,7 +21,7 @@ cdb.admin.MapOptionsDropdown = cdb.ui.common.Dropdown.extend({
     _.defaults(this.options, this.defaults);
 
     this.collection.on("reset", this._setupOptions, this);
-    this.collection.on("change:description", this._setupOptions, this);
+    this.collection.bind("remove", this._setupOptions, this);
 
     this.mapOptions = new cdb.core.Model({
       title:            false,
@@ -55,9 +55,9 @@ cdb.admin.MapOptionsDropdown = cdb.ui.common.Dropdown.extend({
     this._setupOptions();
 
   },
-  
+
   _onMapOptionsChange: function(model, changes) {
-  
+
     _.each(changes.changes, function(value, option) {
 
       var $el = this.$el.find("li." + option);
@@ -119,6 +119,7 @@ cdb.admin.MapOptionsDropdown = cdb.ui.common.Dropdown.extend({
     var simpleOverlays = ["search", "shareable", "zoom", "share", "fullscreen", "layer_selector", "logo"];
     this.mapOptions.set({ scrollwheel: !!this.options.vis.map.get("scrollwheel") });
     this.mapOptions.set({ legends: !!this.options.vis.map.get("legends") });
+    this.mapOptions.set({ title: false, description: false});
 
     _.each(simpleOverlays, function(overlay_type) {
       if (!_.contains(self.collection.pluck("type"), overlay_type)) {
@@ -133,19 +134,16 @@ cdb.admin.MapOptionsDropdown = cdb.ui.common.Dropdown.extend({
 
       if (type === "header") {
 
-        var show_title       = extra.show_title;
-        var show_description = extra.show_description;
+        var show_type = extra.headerType;
 
-        self.mapOptions.set({ title: show_title, description: show_description });
+        self.mapOptions.set(show_type, true);
 
-        if (show_title) {
+        if (show_type === "title") {
           self.$(".title").removeClass("disabled");
         }
 
-        if (show_description) {
+        if (show_type === "description") {
           self.$(".description").removeClass("disabled");
-        } else {
-          self.$(".description").addClass("disabled");
         }
 
       } else if (_.contains(simpleOverlays, type)) {
@@ -329,22 +327,22 @@ cdb.admin.MapOptionsDropdown = cdb.ui.common.Dropdown.extend({
 
     } else if (property === 'title' || property === 'description') {
 
-      var overlay = this.collection.filter(function(m) { return m.get("type") == "header" })[0]
+      var overlay = this.collection.filter(function(m) {
+        var extra = m.get("extra");
+        return extra && extra.headerType === property;
+      })[0];
 
       if (!overlay) {
 
         this.trigger("createOverlay", "header", property);
         return;
 
+      } else {
+        var show_property = this.mapOptions.get(property);
+        if (!show_property) {
+          this.options.collection.remove(overlay);
+        }
       }
-
-      var show_property = this.mapOptions.get(property);
-
-      overlay.set("show_" + property, show_property);
-      overlay.save();
-
-      if ( (!overlay.get("show_title") && !overlay.get("show_description") ) || !overlay.get("show_title") && !overlay.get("description")) this.options.collection.remove(overlay);
-
     }
 
     value ? this.$("li." + property).removeClass("disabled") : this.$("li." + property);

--- a/lib/assets/javascripts/cartodb/table/overlays/header.js
+++ b/lib/assets/javascripts/cartodb/table/overlays/header.js
@@ -1,104 +1,56 @@
 cdb.admin.overlays.Header = cdb.admin.overlays.Text.extend({
 
-  className: "header overlay-static",
+  className: "header overlay-static overlay",
 
   template_name: 'table/views/overlays/header',
 
-  events: { },
+  events: {
 
-  _close:             function() { },
-  _applyStyle:        function() { },
-  _onChangeMode:      function() { },
-  _enableEditingMode: function() { },
-  _onMouseLeave:      function() { },
-  _onMouseEnter:      function() { },
-  _onKeyUp:           function() { },
-  _onKeyDown:         function() { },
+    "mouseenter .text":  "_onMouseEnter",
+
+    "click":             "_onClickEdit",
+    "dblclick":          "_onDblClick",
+
+    "keyup .text":       "_onKeyUp",
+    "paste .text":       "_onPaste"
+
+  },
+
+  form_data: [{
+    name: 'Text',
+    form: {
+      'font-size':  { type: 'simple_number', value: 12, min: 5, max: 50, inc: 2, disable_triggering: true },
+      'color':      { type: 'color', value: '#FFF', extra: { tick: "left", picker_horizontal_position: "left", picker_vertical_position: "down" }},
+      'font-family-name': {
+        type: 'select',
+        value: "Helvetica",
+        extra: ["Helvetica", "Droid Sans", "Vollkorn", "Roboto", "Open Sans", "Lato", "Graduate", "Gravitas One", "Old Standard TT"]
+
+      },
+      'text-align':      { type: 'text_align', value: 'left' }
+    }
+  }, {
+    name: 'Box',
+    form: {
+      'box-color':   { type: 'color', value: '#000', extra: { tick: "left", picker_horizontal_position: "left", picker_vertical_position: "down" }},
+      'box-opacity': { type: 'simple_opacity', value: 0.7, min:0, max:1, inc: 0.1, disable_triggering: true },
+      'box-padding': { type: 'simple_number_with_label', value: 10, min: 5, max: 200, inc: 1, label: "P", disable_triggering: true }
+    }
+  }],
 
   initialize: function() {
 
-    _.bindAll(this, "_close", "_dblClick", "_onChangeMode", "_onKeyDown");
-
-    // Bind ESC key
-    $(document).bind('keydown', this._onKeyDown);
+    _.bindAll(this, "_close", "_onChangeMode", "_onKeyDown");
 
     this.template = this.getTemplate(this.template_name);
 
-    this._setupModel();
+    this._setupModels();
 
+    var extra = this.model.get("extra");
+    this.$el.addClass(extra.headerType);
   },
 
-  _setupModel: function() {
-
-    this.model = this.options.model;
-
-    this.model.set({ mode: "" }, { silent: true })
-
-    this.model.bind('change:show_title',        this._onChangeShowTitle,  this);
-    this.model.bind('change:show_description',  this._onChangeShowDescription,  this);
-
-    this.model.bind('change:style',             this._applyStyle, this);
-    this.model.bind("change:display",           this._onChangeDisplay, this);
-    this.model.bind('change:title',             this._onChangeTitle,  this);
-    this.model.bind('change:description',       this._onChangeDescription,  this);
-    this.model.bind('change:mode',              this._onChangeMode,  this);
-    this.model.bind("change:y",                 this._onChangeY, this);
-
-    this.model.on("destroy", function() {
-      this.$el.remove();
-    }, this);
-
-  },
-
-  isVisible: function() {
-
-    return (this.model.get("title") && this.model.get("show_title")) || (this.model.get("description") && this.model.get("show_description"));
-
-  },
-
-  _dblClick: function(e) {
-
-    this._killEvent(e);
-
-  },
-
-  _onChangeShowDescription: function() {
-
-    var self = this;
-
-    var display         = this.model.get("display");
-    var showTitle       = this.model.get("title") && this.model.get("show_title");
-    var showDescription = this.model.get("description") && this.model.get("show_description");
-    var extra           = this.model.get("extra");
-
-    extra["show_description"] = this.model.get("show_description");
-
-    if (display && showDescription) {
-
-      this.$el.show();
-      this.$description.show();
-
-      this.trigger("change_y");
-
-    } else {
-
-      this.$description.hide();
-      if (!showTitle) this.$el.hide();
-
-      this.trigger("change_y");
-
-    }
-
-    this.model.set({ extra: extra }, { silent: true });
-
-  },
-
-  _onChangeY: function() {
-
-    var y = this.model.get("y");
-    this.$el.animate({ top: y }, 150);
-
-  },
+  isVisible: function() { return this.model.get("display"); },
 
   _onChangeDisplay: function() {
 
@@ -109,134 +61,227 @@ cdb.admin.overlays.Header = cdb.admin.overlays.Text.extend({
     } else {
       this.$el.hide();
     }
-
-  },
-
-  _onChangeShowTitle: function() {
-
-    var self = this;
-
-    var display         = this.model.get("display");
-    var showTitle       = this.model.get("title") && this.model.get("show_title");
-    var showDescription = this.model.get("description") && this.model.get("show_description");
-
-    var extra           = this.model.get("extra");
-    extra["show_title"] = this.model.get("show_title");
-
-    if (display && showTitle) {
-
-      this.$el.show();
-      this.$title.show();
-
-      this.trigger("change_y");
-
-    } else {
-
-      this.$title.hide();
-
-      if (!showDescription) {
-        this.$el.hide();
-      }
-
-      this.trigger("change_y");
-
-    }
-
-    this.model.set({ extra: extra }, { silent: true });
-
-  },
-
-  _onChangeTitle: function() {
-    this.$el.find(".title").html(this.model.get("title"));
-
-    var extra = this.model.get("extra");
-    extra.title = this.model.get("title");
-    this.model.set({ extra: extra }, { silent: true });
-
-    this.show();
-  },
-
-  _onChangeDescription: function() {
-    var description = this.model.get("description");
-    var show_description = true;
-
-    if (!description || !description.trim().length) {
-      show_description = false;
-    }
-
-    this.$(".description").html(
-      this._getMarkdown(description)
-    );
-
-    var extra = this.model.get("extra");
-
-    extra.description = description;
-
-    this.model.save({ extra: extra, show_description: show_description }, { silent: true });
-
-    this.show();
   },
 
   show: function() {
-    var display        = this.model.get("display");
-    var hasTitle       = this.model.get("title") && this.model.get("show_title");
-    var hasDescription = this.model.get("description") && this.model.get("show_description");
-
-    if (display && (hasTitle || hasDescription)) {
-
+    var display = this.model.get("display");
+    if (display) {
       this.$el.show();
-
-      if (hasTitle)       this.$title.show();
-      if (hasDescription) this.$description.show();
-
       this.trigger("change_y");
     }
   },
 
-  hide: function() {},
+  _onChangeY: function() {
 
-  _getMarkdown: function(content) {
+    var y = this.model.get("y");
+    this.$el.animate({ top: y }, 150);
 
-    content = cdb.Utils.stripHTML(content);
-    content = markdown.toHTML(content);
-    content = cdb.Utils.stripHTML(content, '<a><i><em><strong><b><u><s>');
-    content = content.replace(/&#39;/g, "'"); // replaces single quote
-
-    return cdb.core.sanitize.html(content);
+    this.trigger("change_y", this);
 
   },
 
   render: function() {
+    this._place();
 
-    this.$el.offset({
-      top:  this.model.get("y"),
-      left: this.model.get("x")
-    });
+    this.$el.append(this.template(this.model.attributes));
 
-    this.extra = this.model.get("extra");
+    this.$text = this.$(".content div.text");
+    var text   = this._transformToMarkdown(this.model.get("text"));
 
-    this.model.set({
-      title:            this.extra.title,
-      description:      this.extra.description,
-      show_title:       this.extra.show_title,
-      show_description: this.extra.show_description
-    }, { silent: true });
+    this.$text.html(text);
 
-    var attributes = _.chain(this.model.attributes)
-      .clone()
-      .extend({
-        description: this._getMarkdown(this.model.get("description"))
-      })
-      .value();
+    this._applyStyle(false);
+    this._onChangeExtra();
 
-    this.$el.append(this.template(attributes));
-
-    this.$title       = this.$el.find(".content div.title");
-    this.$description = this.$el.find(".content div.description");
+    this.$el.addClass(this.model.get("device"));
 
     this._onChangeDisplay();
 
+    cdb.god.unbind("closeDialogs", this._onCloseDialogs, this);
+    cdb.god.bind("closeDialogs", this._onCloseDialogs, this);
+
+    this.trigger("change_height", this);
     return this;
-  }
+  },
+
+  // Setup the internal and custom model
+  _setupModels: function() {
+
+    var self  = this;
+    var extra = this.model.get("extra");
+
+    this.model.set({ text: extra.text }, { silent: true });
+
+    var applyStyle = function() {
+      self._applyStyle(true);
+      this.trigger("change_height", this);
+    };
+
+    // Binding
+    this.model.bind('remove',   this.hide, this);
+
+    this.model.bind('change:style',    applyStyle,            this);
+    this.model.bind('change:text',     this._setText,         this);
+    this.model.bind('change:display',  this._onChangeDisplay, this);
+    this.model.bind('change:extra',    this._onChangeExtra,   this);
+    this.model.bind('change:selected', this._onChangeSelected, this);
+    this.model.bind("change:y",        this._onChangeY, this);
+
+    // Internal model to store the editing state
+    this.editModel = new cdb.core.Model({ mode: "" });
+    this.editModel.bind('change:mode', this._onChangeMode, this);
+
+    this.add_related_model(this.editModel);
+
+  },
+
+  _setText: function() {
+
+    var text          = this.model.get("text");
+    var rendered_text = this._transformToMarkdown(text);
+
+    var extra = this.model.get("extra");
+
+    extra.text          = text;
+    extra.rendered_text = rendered_text;
+
+    this.model.set({ extra: extra }, { silent: true });
+
+    if (rendered_text) {
+      this.$text.html(rendered_text);
+    }
+
+    this.trigger("change_height", this);
+
+  },
+
+  _onClickEdit: function(e) {
+
+    this.killEvent(e);
+
+    cdb.god.trigger("closeOverlayDropdown");
+
+    $(document).bind('keydown', this._onKeyDown);
+
+    this._savePosition(false);
+
+    this.trigger("clickEdit", this.model, this.form_data);
+
+    this.model.set("selected", true);
+
+  },
+
+  _enableEditingMode: function() {
+
+    this.$el
+    .addClass("editable")
+    .addClass("disabled");
+
+    this.$text.attr("contenteditable", true).focus();
+
+    var style = this.model.get("style");
+    var text = this.model.get("text");
+
+    this.$text.html(text);
+    var self = this;
+    this.$(".hint").fadeIn(150, function() {
+      self.trigger("change_height", self);
+    });
+
+  },
+
+  _disableEditingMode: function() {
+
+    $(document).unbind('keydown', this._onKeyDown);
+
+    var text = this._transformToMarkdown(this.model.get("text"));
+
+    this.editModel.set("mode", "");
+
+    if (!this._isEmptyText(text)) {
+
+      var self = this;
+
+      self.$(".hint").fadeOut(150, function() {
+
+        self.$el
+        .removeClass("editable")
+        .removeClass("disabled");
+
+        self.$text.attr("contenteditable", false);
+
+        setTimeout(function() {
+
+          if (!self.model.isNew()) {
+            self.model.save();
+          }
+
+          self.$text.html(text);
+          self.trigger("change_height", self);
+
+        }, 100);
+
+        if (!self.model.isNew()) {
+          self.model.save();
+        }
+
+      });
+
+    } else {
+      this._close();
+    }
+  },
+  /*
+   * Applies style to the content of the widget
+   */
+  _applyStyle: function(save) {
+
+    var style      = this.model.get("style");
+
+    var boxColor   = style["box-color"];
+    var boxOpacity = style["box-opacity"];
+    var boxPadding = style["box-padding"];
+
+    var fontFamily = style["font-family-name"];
+
+    this.$text.css(style);
+
+    this.$(".content").css("padding", boxPadding);
+    this.$text.css("font-size", style["font-size"] + "px");
+    this.$el.css("z-index", style["z-index"]);
+
+    var rgbaCol = ('rgba(' + parseInt(boxColor.slice(-6,-4),16)
+      + ',' + parseInt(boxColor.slice(-4,-2),16)
+      + ',' + parseInt(boxColor.slice(-2),16)
+      +', ' + boxOpacity + ' )'
+    );
+
+    this.$el.css("background-color", rgbaCol);
+
+    var fontFamilyClass = "";
+
+    if      (fontFamily  == "Droid Sans")       fontFamilyClass = "droid";
+    else if (fontFamily  == "Vollkorn")         fontFamilyClass = "vollkorn";
+    else if (fontFamily  == "Open Sans")        fontFamilyClass = "open_sans";
+    else if (fontFamily  == "Roboto")           fontFamilyClass = "roboto";
+    else if (fontFamily  == "Lato")             fontFamilyClass = "lato";
+    else if (fontFamily  == "Graduate")         fontFamilyClass = "graduate";
+    else if (fontFamily  == "Gravitas One")     fontFamilyClass = "gravitas_one";
+    else if (fontFamily  == "Old Standard TT")  fontFamilyClass = "old_standard_tt";
+
+    this.$el
+    .removeClass("droid")
+    .removeClass("vollkorn")
+    .removeClass("roboto")
+    .removeClass("open_sans")
+    .removeClass("lato")
+    .removeClass("graduate")
+    .removeClass("gravitas_one")
+    .removeClass("old_standard_tt");
+
+    this.$el.addClass(fontFamilyClass);
+
+    if (save) this.model.save();
+  },
 
 });

--- a/lib/assets/javascripts/cartodb/table/overlays/map_overlays.js
+++ b/lib/assets/javascripts/cartodb/table/overlays/map_overlays.js
@@ -45,8 +45,9 @@ cdb.admin.MapOverlays = cdb.core.View.extend({
     return this.overlays.filter(function(m) { return m.get("type") == type })[0];
   },
 
-  getHeaderOverlay: function() {
-    return this.getOverlay("header");
+  getHeaderOverlays: function() {
+    if (!this.overlays) return;
+    return this.overlays.filter(function(m) { return m.get("type") === "header"; });
   },
 
   _hideOverlays: function(mode) {
@@ -196,11 +197,8 @@ cdb.admin.MapOverlays = cdb.core.View.extend({
 
     if (!this.overlays) return;
 
-    if (move_header) {
-
-      var header = this.getHeaderOverlay();
-      this._positionOverlay(header);
-    }
+    var headers = this.getHeaderOverlays();
+    _.each(headers, this._positionOverlay, this);
 
     _.each(this.horizontal_overlays, function(type) {
 
@@ -658,11 +656,18 @@ cdb.admin.MapOverlays = cdb.core.View.extend({
   },
 
   _setupHeaderOverlay: function(type, data) {
-
-    var overlay = this.header = new cdb.admin.overlays[type]({
+    var extra = data.get("extra");
+    var headerType = extra.headerType;
+    if (!headerType) { // Old-style header; ignore for now.
+      return;
+    }
+    if (!this.header) this.header = {};
+    var overlay = this.header[headerType] = new cdb.admin.overlays[type]({
       model: data,
       map: this.map
     });
+
+    overlay.show();
 
     this._bindHeaderOverlay(overlay);
 
@@ -673,27 +678,35 @@ cdb.admin.MapOverlays = cdb.core.View.extend({
   _bindHeaderOverlay: function(overlay) {
 
     var self = this;
+    var extra = overlay.model.get("extra");
+    var destroyType = extra.headerType;
 
     var onDestroy = function() {
-
-      if (self.header) {
-        self.header.clean();
+      self.header[destroyType].clean();
+      delete self.header[destroyType];
+      if (!self.header.title && !self.header.description) {
         delete self.header;
       }
-
       self._positionOverlaysVertically();
-
     };
 
     overlay.bind("change_y", this._positionOverlaysVertically, this);
+    overlay.bind("change_height", this._positionOverlaysVertically, this);
     overlay.model.bind("destroy", onDestroy, this);
 
   },
 
+  // Get height of all header overlays, since there can now be more than one.
   _getHeaderHeight: function() {
+    var totalHeaderHeight = 0;
+    $(".header.overlay-static").each(function(index, value) {
+      totalHeaderHeight += $(value).outerHeight(true);
+    });
+    return totalHeaderHeight;
+  },
 
-    return $(".header.overlay-static").outerHeight(true) || 20;
-
+  _getTitleHeight: function() {
+    return $(".header.overlay-static.title").outerHeight(true);
   },
 
   _positionOverlay: function(overlay_model) {
@@ -702,7 +715,15 @@ cdb.admin.MapOverlays = cdb.core.View.extend({
 
     var type = overlay_model.get("type");
 
-    if      (type === 'header')         this._positionHeaderOverlay(overlay_model);
+    if (type === 'header') {
+      var extra = overlay_model.get('extra');
+      var header_type = extra.headerType;
+      if (header_type === 'title') {
+        this._positionTitleOverlay(overlay_model);
+      } else if (header_type === 'description') {
+        this._positionDescriptionOverlay(overlay_model);
+      }
+    }
     else if (type === 'zoom')           this._positionZoomOverlay(overlay_model);
     else if (type === 'fullscreen')     this._positionFullScreenOverlay(overlay_model);
     else if (type === 'share')          this._positionShareOverlay(overlay_model);
@@ -712,11 +733,18 @@ cdb.admin.MapOverlays = cdb.core.View.extend({
 
   },
 
-  _positionHeaderOverlay: function(overlay_model) {
+  _positionTitleOverlay: function(overlay_model) {
 
     if (this.headerMessageIsVisible && this.canvas.get("mode") === 'desktop') overlay_model.set("y", 20);
     else overlay_model.set("y", 0);
 
+  },
+
+  _positionDescriptionOverlay: function(overlay_model) {
+    var titleHeight = this._getTitleHeight();
+    if (this.headerMessageIsVisible && this.canvas.get("mode") === 'desktop') overlay_model.set("y", titleHeight + 20);
+    else if (titleHeight > 0) overlay_model.set("y", titleHeight);
+    else                      overlay_model.set("y", 0);
   },
 
   _positionSearchOverlay: function(overlay_model) {

--- a/lib/assets/javascripts/cartodb/table/overlays/overlays.js
+++ b/lib/assets/javascripts/cartodb/table/overlays/overlays.js
@@ -70,7 +70,7 @@ cdb.admin.models.Overlay = cdb.core.Model.extend({
         extra:   this.get("extra")
       }
     }
-  }, 
+  },
 
   parse: function(resp) {
     resp.display = resp.options.display;
@@ -149,7 +149,7 @@ cdb.admin.Overlays = Backbone.Collection.extend({
    * */
   getOverlaysZIndex: function(mode) {
 
-    var overlays = this.filter(function(o) { 
+    var overlays = this.filter(function(o) {
       return o.get("device") === mode && (o.get("type") === "text" || o.get("type") === "annotation" || o.get("type") === "image");
     });
 
@@ -240,38 +240,65 @@ cdb.admin.Overlays = Backbone.Collection.extend({
 
     var self = this;
 
-    var show_title       = false;
-    var show_description = false;
+    var defaultStyle = {
+      "z-index":          4,
+      "color":            "#ffffff",
+      "text-align":       "left",
+      "font-size":        property === "title" ? "20" : "12",
+      "font-family-name": "Helvetica",
+      "box-padding":      10,
+      "box-color":        "#000000",
+      "box-opacity":      0.7,
+    };
 
-    if (property === "title")       show_title       = true;
-    if (property === "description") show_description = true;
+    var text;
+    var rendered_text; // Rendered version of the markdown text
+    if (property === "title") {
+      text = this.vis.get("name");
+      rendered_text = text;
+    } else if (property === "description") {
+      text = this.vis.get("description");
+      if (!text) {
+        text = "Write a description of your map here.";
+      }
+      rendered_text = this._getMarkdown(text);
+    }
 
-    var description = this.vis.get("description");
-    var title       = this.vis.get("name");
-
-    if (!show_title && property == 'description' && !description) return;
+    if (property == 'description' && !text) return;
 
     var options = {
       type: "header",
       order: 1,
       display: true,
       extra: {
-        title: title,
-        description: description,
-        show_title: show_title,
-        show_description: show_description
-      }
+        headerType: property,
+        text: text,
+        rendered_text: text
+      },
+      style: defaultStyle,
+      x: "0",
+      y: "0"
     };
 
     var model = this.create(options);
     var vis = this.vis;
 
-    this.vis.on("change:name change:description", function() {
-      model.set({
-        title:  vis.get("name"),
-        description: self._getMarkdown(vis.get('description'))
-      });
-    }, model);
+    if (property === "title") {
+      this.vis.on("change:name", function() {
+        var newText = vis.get("name");
+        model.set({
+          text: newText,
+          rendered_text: newText
+        });
+      }, model);
+    } else if (property === "description") {
+      this.vis.on("change:description", function() {
+        model.set({
+          text:  vis.get("description"),
+          rendered_text: self._getMarkdown(vis.get("description"))
+        });
+      }, model);
+    }
 
     model.bind('destroy', function() {
       vis.unbind(null, null, model);

--- a/lib/assets/javascripts/cartodb/table/views/overlays/header.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/overlays/header.jst.ejs
@@ -1,4 +1,4 @@
 <div class="content">
-  <div class="title"><%- title %></div>
-  <div class="description"><%- description %></div>
+  <div class="text overlay_text"></div>
+  <div class="hint"><strong>**bold**</strong> <em>*italics*</em> <span>[link title](url)</span></div>
 </div>

--- a/lib/assets/test/spec/cartodb/table/map_options_dropdown.spec.js
+++ b/lib/assets/test/spec/cartodb/table/map_options_dropdown.spec.js
@@ -34,15 +34,11 @@ describe("map_options_dropdown", function() {
     this.header = new cdb.core.Model({
       order: 1,
       shareable: false,
-      description: "Description",
-      title: "Hello!",
       type: "header",
       url: null,
       extra: {
-        description: "Description",
-        title: "Hello!",
-        show_title: true,
-        show_description: true
+        headerType: "description",
+        text: "Description"
       }
     });
 
@@ -92,9 +88,7 @@ describe("map_options_dropdown", function() {
   it("should change disabled the description option when show_description is false ", function() {
     this.view.render();
     expect(this.view.$('.switches li.description').hasClass("active")).toBe(true);
-    var extra = this.header.get("extra");
-    extra.show_description = false;
-    this.header.set({ extra: extra, description: "" });
+    this.overlays.remove(this.header);
     expect(this.view.$('.switches li.description').hasClass("active")).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #4 . Allows title and description headers to be edited by clicking / double-clicking on them, similarly to existing text and title overlays.

There are still a few minor bugs outstanding but I think this is ready for review. Known issues:
- After deleting an element, a console error is thrown saying "no element found"; this doesn't seem to impact functionality.
- Clicking inside a title / description overlay in text-edit mode does not position the text input cursor (but it does for regular text overlays).
- The other overlays do not always immediately respond to changes in the header overlays' size due to changes in edit mode and/or styling. I had fixed this but appear to have re-broken it in the course of fixing another positioning bug.
- Font styling doesn't appear to be taking effect; the correct value is being saved to the element style, so this may simply be a problem with our development setup.
