### PR TITLE
Add global toggle to use OR vs AND in filters pane

### DIFF
--- a/app/assets/stylesheets/table/table_panel/layer-views-panels/filters_panel.css.scss
+++ b/app/assets/stylesheets/table/table_panel/layer-views-panels/filters_panel.css.scss
@@ -35,6 +35,10 @@
 
     }
 
+    .sql-and-or-toggle {
+      margin-right: 15px;
+    }
+
     .content {
       position:relative;
 

--- a/lib/assets/javascripts/cartodb/models/filter.js
+++ b/lib/assets/javascripts/cartodb/models/filter.js
@@ -579,6 +579,10 @@ cdb.admin.models.Filters = Backbone.Collection.extend({
       throw "Filters need a table";
     }
     this.table = options.table;
+    if (!options.dataLayer) {
+      throw "Filters need a dataLayer";
+    }
+    this.dataLayer = options.dataLayer;
   },
 
   getSQLCondition: function() {
@@ -587,7 +591,8 @@ cdb.admin.models.Filters = Backbone.Collection.extend({
       return f.getSQLCondition();
     })
 
-    var sql = _(sqls).compact().join(' AND ');
+    var operator = this.dataLayer.get('sql_or_toggle') ? ' OR ' : ' AND ';
+    var sql = _(sqls).compact().join(operator);
 
     return sql;
   },

--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters.js
@@ -154,7 +154,8 @@ cdb.admin.mod.Filters = cdb.admin.Module.extend({
       this.options.table.unbind('change:original_schema', this.initFilters, this);
 
       this.filters = new cdb.admin.models.Filters(null, {
-        table: this.options.table
+        table: this.options.table,
+        dataLayer: this.options.dataLayer
       });
 
       this.excludedColumNames = [];
@@ -213,6 +214,14 @@ cdb.admin.mod.Filters = cdb.admin.Module.extend({
 
     },
 
+    _addOrToggleSwitch: function () {
+      this.orSwitch = new cdb.forms.Switch({
+        el: this.$el.find(".switch"),
+        model: this.options.dataLayer,
+        property: "sql_or_toggle"
+      });
+    },
+
     changeSQLEvents: [
        'add',
        'remove',
@@ -227,10 +236,12 @@ cdb.admin.mod.Filters = cdb.admin.Module.extend({
 
     _bindChangeQuery: function() {
       this.filters.bind(this.changeSQLEvents, this._filtersChanged, this);
+      this.options.dataLayer.bind('change:sql_or_toggle', this._filtersChanged, this);
     },
 
     _unbindChangeQuery: function() {
       this.filters.unbind(this.changeSQLEvents, this._filtersChanged, this);
+      this.options.dataLayer.unbind('change:sql_or_toggle', this._filtersChanged, this);
     },
 
     _onSchemaUpdate: function() {
@@ -483,7 +494,10 @@ cdb.admin.mod.Filters = cdb.admin.Module.extend({
 
       var isQueryApplied = (query && sqlSource != 'filters');
 
-      this.$el.html(template({ isQueryApplied: isQueryApplied }));
+      this.$el.html(template({
+        isQueryApplied: isQueryApplied,
+        sql_or_toggle: this.options.dataLayer.get('sql_or_toggle')
+      }));
 
       this.$el.find('.chooser').append(this.columnSelector.render().el);
       this.$el.find('.combo').prepend(this.innerColumnSelector.render().el);
@@ -497,6 +511,8 @@ cdb.admin.mod.Filters = cdb.admin.Module.extend({
       if (isQueryApplied) {
         this._showQueryAppliedMessage();
       }
+
+      this._addOrToggleSwitch();
 
       return this;
     }

--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters/templates/filters.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters/templates/filters.jst.ejs
@@ -1,4 +1,9 @@
-<h3>Filters</h3>
+<h3>Filters
+  <div class="right sql-and-or-toggle">
+    <a href="#switch" class="switch<% if (sql_or_toggle) { %> enabled<% } else { %> disabled<% } %>"><span class="handle"></span></a>
+    <label>Use OR</label>
+  </div>
+</h3>
 
 <div class="main white-gradient-shadow top"></div>
 <div class="content">

--- a/lib/assets/test/spec/cartodb/models/filters.spec.js
+++ b/lib/assets/test/spec/cartodb/models/filters.spec.js
@@ -5,11 +5,13 @@ describe('modules.Filters', function() {
   //===================================================
   describe('cdb.admin.models.Filters', function() {
 
-    var filters, table;
+    var filters, table, dataLayer;
     beforeEach(function() {
       table = TestUtil.createTable('test');
+      dataLayer = new cdb.core.Model({ sql_or_toggle: false});
       filters = new cdb.admin.models.Filters(null, {
-        table: table
+        table: table,
+        dataLayer: dataLayer
       });
     });
 


### PR DESCRIPTION
All individual filters will be joined by OR if enabled,
otherwise AND.

![bb-global-or-1](https://cloud.githubusercontent.com/assets/1818302/13500373/456ae5c6-e130-11e5-9682-0535282bc34a.png)
![bb-global-or-2](https://cloud.githubusercontent.com/assets/1818302/13500374/456c39e4-e130-11e5-9095-729f4582b592.png)
