### PR TITLE
Dismiss custom sql banner on viz page via link in banner

### DIFF
--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -199,6 +199,7 @@ cdb.admin.MapTab = cdb.core.View.extend({
     'click .export_image.button':  '_exportImage',
     'click .sqlview .clearview':   '_clearView',
     'click .sqlview .export_query':'_tableFromQuery',
+    'click .sqlview .dismiss':'_dismissSQLView',
     'keydown':'_onKeyDown'
   },
 
@@ -1666,6 +1667,11 @@ cdb.admin.MapTab = cdb.core.View.extend({
     this.killEvent(e);
     this.activeLayerView.model.clearSQLView();
     return false;
+  },
+
+  _dismissSQLView: function (e) {
+    this.killEvent(e);
+    this._removeSQLViewHeader();
   },
 
   _tableFromQuery: function(e) {

--- a/lib/assets/javascripts/cartodb/table/tableview.js
+++ b/lib/assets/javascripts/cartodb/table/tableview.js
@@ -11,6 +11,7 @@
       events: cdb.core.View.extendEvents({
           'click .clearview': '_clearView',
           'click .sqlview .export_query': '_tableFromQuery',
+          'click .sqlview .dismiss': '_dismissSQLHeader',
           'click .noRows': 'addEmptyRow'
       }),
 
@@ -309,6 +310,12 @@
 
           self._moveInfo();
         }
+      },
+
+      _dismissSQLHeader: function (e) {
+        this.killEvent(e);
+        this.$('thead').find('.sqlview').remove();
+        this.$('thead > tr').css('height', '');
       },
 
       // depending if the sync is enabled add or remove a class

--- a/lib/assets/javascripts/cartodb/table/views/sql_view_notice.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/sql_view_notice.jst.ejs
@@ -8,5 +8,6 @@
     <% } else { %>
       No resulting rows for this query, <a href="#/clear-view" class="clearview">clear this sql view</a>
     <% } %>
+    or <a href="#/dismiss" class="dismiss">dismiss</a>.
   </p>
 </div>


### PR DESCRIPTION
Banner is only dismissed until a route change, page refresh
or sql update brings it back.

TODO: Dismiss persists through route/page changes?

@javisantana what would the best way (within the framework of whats here) to persist the notification remaining hidden across page refreshes and state changes, but not if the user updates the SQL for the layer or applies/updates the filters?
