### PR TITLE
Fixup cdb submodule by adding subproject commit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "lib/assets/javascripts/cdb"]
-	path = lib/assets/javascripts/cdb
-  url = git://github.com/cartodb-org/cartodb.js.git
-	branch = develop
+    path = lib/assets/javascripts/cdb
+    url = git://github.com/cartodb-org/cartodb.js.git
+    branch = develop
 [submodule "app/assets/stylesheets/old_common"]
 	path = app/assets/stylesheets/old_common
 	url = git://github.com/CartoDB/cartodb.css.git


### PR DESCRIPTION
Just a heads up to @javisantana, looks like submodule commit wasn't applied to this branch, leading to git thinking the submodule wasn't there when the `bbg_production` branch was checked out.
