### PR TITLE
Disable global AND/OR toggle in filter pane

### DIFF
--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters/templates/filters.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters/templates/filters.jst.ejs
@@ -1,9 +1,4 @@
-<h3>Filters
-  <div class="right sql-and-or-toggle">
-    <a href="#switch" class="switch<% if (sql_or_toggle) { %> enabled<% } else { %> disabled<% } %>"><span class="handle"></span></a>
-    <label>Use OR</label>
-  </div>
-</h3>
+<h3>Filters</h3>
 
 <div class="main white-gradient-shadow top"></div>
 <div class="content">


### PR DESCRIPTION
Removes the interface from the template but leaves the rest of the
machinery in place. Filters will be ANDed.
