### PR TITLE
Feature/title layer panel toggle

### DIFF
--- a/app/assets/stylesheets/old_elements/dialog_small_edit.css.scss
+++ b/app/assets/stylesheets/old_elements/dialog_small_edit.css.scss
@@ -126,7 +126,7 @@
       word-spacing: -4px;
 
       .select2-container {width:100px!important;}
-      
+
       & > div.column {
         @include inline-block();
         letter-spacing: 0;
@@ -164,7 +164,7 @@
         }
 
         &:last-child {margin-right:0;}
-      }      
+      }
     }
 
 
@@ -279,7 +279,7 @@
         top:6px;
         left:8px;
         font-style:italic;
-        color:#AAAAAA; 
+        color:#AAAAAA;
         font-size:13px;
         pointer-events:none;
         z-index:10;
@@ -292,6 +292,7 @@
   }
 }
 .floating.edit_name_dialog {
+  z-index:10000;
   min-width:280px;
   height:37px;
   padding: 5px;

--- a/app/assets/stylesheets/table/table_panel/add_layer.css.scss
+++ b/app/assets/stylesheets/table/table_panel/add_layer.css.scss
@@ -1,6 +1,6 @@
 
   /**
-   *  Trick 'add layer' panel styles
+   *  Trick 'layer title' panel styles
    */
 
   @import "compass/css3/inline-block";
@@ -12,7 +12,7 @@
   @import "../../old_common/mixins";
 
 
-  .add_layer {
+  .change_title {
     position:relative;
     height:55px;
     margin-top:-15px;
@@ -25,8 +25,8 @@
       text-decoration: none;
     }
 
-    // Add layer
-    // (Add layer button)
+    // Change title
+    // (Add change title button)
     .add {
       @include inline-block();
       width:16px;
@@ -41,7 +41,7 @@
       @include background(sprite($table-sprites, add_layer, $offset-x:0, $offset-y:0) no-repeat);
     }
 
-    // (Add layer text)
+    // (Title layer text)
     .action {
       @include inline-block();
       margin:0 0 0 27px;

--- a/app/assets/stylesheets/table/table_panel/add_layer.css.scss
+++ b/app/assets/stylesheets/table/table_panel/add_layer.css.scss
@@ -6,13 +6,11 @@
   @import "compass/css3/inline-block";
   @import "compass/css3/transform";
   @import "compass/css3/transition";
-  @import "compass/css3/images";
-  @import "../../table/table-sprite";
   @import "../../old_common/vars";
   @import "../../old_common/mixins";
 
 
-  .change_title {
+  .title_layer {
     position:relative;
     height:55px;
     margin-top:-15px;
@@ -26,23 +24,8 @@
     }
 
     // Change title
-    // (Add change title button)
-    .add {
-      @include inline-block();
-      width:16px;
-      height:16px;
-      margin:0 0 0 23px;
-      line-height:16px;
-      text-align:center;
-      color:#ECECEC;
-      background:#A9A9A9;
-      @include text-indent();
-      @include border-radius(2px);
-      @include background(sprite($table-sprites, add_layer, $offset-x:0, $offset-y:0) no-repeat);
-    }
-
     // (Title layer text)
-    .action {
+    .action.title {
       @include inline-block();
       margin:0 0 0 27px;
       font:500 17px $text-fonts;
@@ -54,7 +37,6 @@
       height:70px;
       cursor:pointer;
 
-      .add { @include background(sprite($table-sprites, add_layer, $offset-x:0, $offset-y:-16px) no-repeat); }
-      .action { color: #3A77A6; }
+      .action.title { color: #3A77A6; }
     }
   }

--- a/app/assets/stylesheets/table/table_panel/add_title_layer.css.scss
+++ b/app/assets/stylesheets/table/table_panel/add_title_layer.css.scss
@@ -9,7 +9,6 @@
   @import "../../old_common/vars";
   @import "../../old_common/mixins";
 
-
   .title_layer {
     position:relative;
     height:55px;

--- a/app/assets/stylesheets/table/table_panel/layer-views-panels/wizard_panel.css.scss
+++ b/app/assets/stylesheets/table/table_panel/layer-views-panels/wizard_panel.css.scss
@@ -322,9 +322,9 @@
       }
     }
   }
-  
+
   /* Temporary hack for a Chrome v45 bug */
   /* https://github.com/CartoDB/cartodb/issues/5368 */
-  .select2-result-label td.color { 
+  .select2-result-label td.color {
      width: 10%;
   }

--- a/app/assets/stylesheets/table/table_panel/table_panel.css.scss
+++ b/app/assets/stylesheets/table/table_panel/table_panel.css.scss
@@ -15,7 +15,7 @@ $corner_radius: 6px;
 .table_panel {
   position:fixed;
   right:-537px;
-  top:64px;
+  top:80px;
   bottom:0px;
   width:600px;
   padding-top:25px;
@@ -92,7 +92,7 @@ $corner_radius: 6px;
 
   // Active layer
   .layer_panel.active {
-    margin-bottom:20px;
+    margin-bottom:5px;
     padding-bottom:0;
 
     .layer-info .info {

--- a/app/assets/stylesheets/table/table_panel/table_panel.css.scss
+++ b/app/assets/stylesheets/table/table_panel/table_panel.css.scss
@@ -26,9 +26,23 @@ $corner_radius: 6px;
   border-right:0;
   background:#EDEDED;
   @include box-shadow(rgba(black,0.15) 0 0 2px 2px);
-  @include border-top-left-radius($corner_radius);
   z-index:20;
 
+  .collapse {
+    position: absolute;
+    width: 43px;
+    height: 43px;
+    top: -1px;
+    background-color: #EDEDED;
+    border-radius: 6px 0px 0px 6px;
+    border: 1px solid rgba(0, 0, 0, 0.4);
+    @include table-sprite(wizard-arrows, $offset-x:0px);
+
+    &.open {
+      background-color: #EDEDED;
+      @include table-sprite(wizard-arrows, $offset-x:-43px);
+    }
+  }
 
   .layer_panel {
     position:relative;

--- a/lib/assets/javascripts/cartodb/old_common/header.js
+++ b/lib/assets/javascripts/cartodb/old_common/header.js
@@ -44,7 +44,6 @@ cdb.admin.Header = cdb.core.View.extend({
   _MAX_DESCRIPTION_LENGTH: 200,
 
   events: {
-    //'click a.title':        '_changeTitle',
     'click .metadata a':    '_changeMetadata',
     'click a.options':      '_openOptionsMenu',
     'click a.share':        '_shareVisualization',
@@ -88,7 +87,6 @@ cdb.admin.Header = cdb.core.View.extend({
   },
 
   _initBinds: function() {
-    //this.model.bind('change:name',        this._setName,            this);
     this.model.bind('change:type',        this.setInfo,             this);
     this.model.bind('change:privacy',     this._setPrivacy,      this);
     this.model.bind('change:permission',  this._setSharedCount,  this);
@@ -172,7 +170,6 @@ cdb.admin.Header = cdb.core.View.extend({
    *  Set visualization info
    */
   setInfo: function() {
-    //this._setName();
     this._setSyncInfo();
     this._setVisualization();
     this._setMetadata();
@@ -182,7 +179,6 @@ cdb.admin.Header = cdb.core.View.extend({
    *  Set editable visualization info
    */
   setEditableInfo: function() {
-    //this._setName();
     this._setSyncInfo();
     this._setMetadata();
   },
@@ -318,19 +314,6 @@ cdb.admin.Header = cdb.core.View.extend({
     }
   },
 
-  /**
-   *  Set name of the visualization
-   */
-/*  _setName: function() {
-    var $title = this.$('h1 a.title');
-
-    $title
-      [(this.isVisEditable() && !this.isSyncTable()) ? 'removeClass' : 'addClass' ]('disabled')
-      .text(this.model.get('name'))
-
-    document.title = this.model.get('name') + " | CartoDB";
-  },*/
-
 
   /**
    *  Set visualization type and change share button
@@ -382,93 +365,6 @@ cdb.admin.Header = cdb.core.View.extend({
       window.table_router.addToHistory();
     }
   },
-
-  /**
-   *  Change visualization title
-   */
- /*
-  _changeTitle: function(e) {
-    this.killEvent(e);
-
-    var self = this;
-    var isOwner = this.model.permission.isOwner(this.options.user);
-
-    if (this.isVisEditable()) {
-      this.title_dialog && this.title_dialog.clean();
-      cdb.god.trigger("closeDialogs");
-
-      var title_dialog = this.title_dialog = new cdb.admin.EditTextDialog({
-        initial_value: this.model.get('name'),
-        template_name: 'table/views/edit_name',
-        clean_on_hide: true,
-        modal_class: 'edit_name_dialog',
-        onResponse: setTitle
-      });
-
-      cdb.god.bind("closeDialogs", title_dialog.hide, title_dialog);
-
-      // Set position and show
-      var pos = $(e.target).offset();
-      pos.left -= $(window).scrollLeft()
-      pos.top -= $(window).scrollTop()
-      var w = Math.max($(e.target).width() + 100, 280);
-      title_dialog.showAt(pos.left - 20, pos.top - 10, w);
-    } else {
-      var $el = $(e.target);
-      $el
-        .bind('mouseleave', destroyTipsy)
-        .tipsy({
-          fade:     true,
-          trigger:  'manual',
-          html:     true,
-          title:    function() {
-            var mode = self.isSyncTable() ? 'sync' : 'read-only';
-            return _.template(self._TEXTS.rename[ !isOwner ? 'owner' : 'readonly' ])({ mode: mode })
-          }
-        })
-        .tipsy('show')
-    }
-
-    function destroyTipsy() {
-      var $el = $(this);
-      var tipsy = $el.data('tipsy');
-      if (tipsy) {
-        $el
-          .tipsy('hide')
-          .unbind('mouseleave', destroyTipsy);
-      }
-    }
-
-    function setTitle(val) {
-      if (val !== self.model.get('name') && val != '') {
-        // Sanitize description (html and events)
-        var title = cdb.Utils.stripHTML(val,'');
-
-        if (self.model.isVisualization()) {
-          self._onSetAttributes({ name: title });
-        } else {
-          // close any prev modal if existing
-          if (self.change_confirmation) {
-            self.change_confirmation.clean();
-          }
-          self.change_confirmation = cdb.editor.ViewFactory.createDialogByTemplate('common/dialogs/confirm_rename_dataset');
-
-          // If user confirms, app set the new name
-          self.change_confirmation.ok = function() {
-            self._onSetAttributes({ name: title });
-            if (_.isFunction(this.close)) {
-              this.close();
-            }
-          };
-
-          self.change_confirmation
-            .appendToBody()
-            .open();
-        }
-      }
-    }
-  },
-*/
 
 
   /**

--- a/lib/assets/javascripts/cartodb/old_common/header.js
+++ b/lib/assets/javascripts/cartodb/old_common/header.js
@@ -44,7 +44,7 @@ cdb.admin.Header = cdb.core.View.extend({
   _MAX_DESCRIPTION_LENGTH: 200,
 
   events: {
-    'click a.title':        '_changeTitle',
+    //'click a.title':        '_changeTitle',
     'click .metadata a':    '_changeMetadata',
     'click a.options':      '_openOptionsMenu',
     'click a.share':        '_shareVisualization',
@@ -54,7 +54,7 @@ cdb.admin.Header = cdb.core.View.extend({
 
   initialize: function(options) {
 
-    _.bindAll(this, '_changeTitle', '_setPrivacy');
+    _.bindAll(this, '_setPrivacy');
 
     this.$body = $('body');
     this.dataLayer = null;
@@ -88,7 +88,7 @@ cdb.admin.Header = cdb.core.View.extend({
   },
 
   _initBinds: function() {
-    this.model.bind('change:name',        this._setName,            this);
+    //this.model.bind('change:name',        this._setName,            this);
     this.model.bind('change:type',        this.setInfo,             this);
     this.model.bind('change:privacy',     this._setPrivacy,      this);
     this.model.bind('change:permission',  this._setSharedCount,  this);
@@ -172,7 +172,7 @@ cdb.admin.Header = cdb.core.View.extend({
    *  Set visualization info
    */
   setInfo: function() {
-    this._setName();
+    //this._setName();
     this._setSyncInfo();
     this._setVisualization();
     this._setMetadata();
@@ -182,7 +182,7 @@ cdb.admin.Header = cdb.core.View.extend({
    *  Set editable visualization info
    */
   setEditableInfo: function() {
-    this._setName();
+    //this._setName();
     this._setSyncInfo();
     this._setMetadata();
   },
@@ -321,7 +321,7 @@ cdb.admin.Header = cdb.core.View.extend({
   /**
    *  Set name of the visualization
    */
-  _setName: function() {
+/*  _setName: function() {
     var $title = this.$('h1 a.title');
 
     $title
@@ -329,7 +329,7 @@ cdb.admin.Header = cdb.core.View.extend({
       .text(this.model.get('name'))
 
     document.title = this.model.get('name') + " | CartoDB";
-  },
+  },*/
 
 
   /**
@@ -386,6 +386,7 @@ cdb.admin.Header = cdb.core.View.extend({
   /**
    *  Change visualization title
    */
+ /*
   _changeTitle: function(e) {
     this.killEvent(e);
 
@@ -467,7 +468,7 @@ cdb.admin.Header = cdb.core.View.extend({
       }
     }
   },
-
+*/
 
 
   /**

--- a/lib/assets/javascripts/cartodb/table/actions_menu.js
+++ b/lib/assets/javascripts/cartodb/table/actions_menu.js
@@ -18,6 +18,8 @@
     animation_time: 300,
 
     _TEXTS: {
+      saving:         _t('Saving...'),
+      saved:          _t('Saved'),
       sort: {
         torque: _t('Animated layers must be on top of other layers.'),
         tiled:  _t('Tiled layers can\'t be above animated layers.')
@@ -31,7 +33,7 @@
     _MAX_DESCRIPTION_LENGTH: 200,
 
     events: {
-      'click a.title':    '_changeTitle'
+      'click .title_label':    '_changeTitle'
     },
 
     initialize: function() {
@@ -65,13 +67,15 @@
         activeWorkView: 'table'
       });
 
-      // Display all the visualization info
+      // Display visualization title info
       this._setName();
-      this.vis.bind('change:name', this._setName, this);
+
       // Bind model changes
       this.model.bind('change:open', this._setPanelState, this);
+      this.model.bind('change:state change:connected', this.render, this);
 
       // Visualization changes
+      this.vis.bind('change:name', this._setName, this);
       this.vis.bind('change:type', this.hide, this);
       this.add_related_model(this.vis);
 
@@ -82,7 +86,7 @@
      *  Set name of the visualization
      */
     _setName: function() {
-      var $title = this.$('h1 a.title');
+      var $title = this.$('a span.title');
 
       $title
         [(this.isVisEditable())? 'removeClass' : 'addClass' ]('disabled')
@@ -152,7 +156,7 @@
           var title = cdb.Utils.stripHTML(val,'');
 
           if (self.vis.isVisualization()) {
-            self._onSetAttributes({ name: title });
+            self._onSetVisAttributes({ name: title });
           } else {
             // close any prev modal if existing
             if (self.change_confirmation) {
@@ -162,7 +166,7 @@
 
             // If user confirms, app set the new name
             self.change_confirmation.ok = function() {
-              self._onSetAttributes({ name: title });
+              self._onSetVisAttributes({ name: title });
               if (_.isFunction(this.close)) {
                 this.close();
               }
@@ -172,8 +176,42 @@
               .appendToBody()
               .open();
           }
-          self.render();
         }
+      }
+    },
+
+  /*
+  *  Wait function before set new visualization title
+  */
+    _onSetVisAttributes: function(d) {
+
+      var old_data = this.vis.toJSON();
+      var new_data = d;
+
+      this.vis.set(d, { silent: true });
+
+      // Check if there is any difference
+      if (this.vis.hasChanged()) {
+        var self = this;
+
+        this.globalError.showError(this._TEXTS.saving, 'load', -1);
+
+        this.vis.save({},{
+          wait: true,
+          success: function(m) {
+            // Check if attr saved is name to change url
+            if (new_data.name !== old_data.name && !self.vis.isVisualization()) {
+              window.table_router.navigate(self._generateTableUrl(), {trigger: false});
+              window.table_router.addToHistory();
+            }
+            self.globalError.showError(self._TEXTS.saved, 'info', 3000);
+          },
+          error: function(msg, resp) {
+            var err =  resp && JSON.parse(resp.responseText).errors[0];
+            self.globalError.showError(err, 'error', 3000);
+            self.vis.set(old_data, { silent: true });
+          }
+        });
       }
     },
 
@@ -216,7 +254,7 @@
 
     _addLayers: function(layers) {
       // Add 'title' button first
-      this._addLayerAddButton();
+      this._addTitleLayer();
 
       // Add layers
       var self = this;
@@ -330,12 +368,11 @@
       }
     },
 
-    /* Add layer functions */
+    /* Add title layer functions */
+    _addTitleLayer: function() {
+      this.$('.title_layer').remove();
 
-    _addLayerAddButton: function() {
-      this.$('a.change-title').remove();
-
-      var template = this.getTemplate('table/views/add_layer');
+      var template = this.getTemplate('table/views/add_title_layer');
       var d = {
         'title': this.vis.get('name')
       };
@@ -470,7 +507,7 @@
             if (!this.sortTooltip) this._addSortTooltip(e, 'torque');
           }
 
-          this.$('section.change_title').after(
+          this.$('div.title_label').after(
             $(ui.placeholder)
               .outerHeight(active_height)
               .css('display','block')

--- a/lib/assets/javascripts/cartodb/table/actions_menu.js
+++ b/lib/assets/javascripts/cartodb/table/actions_menu.js
@@ -31,7 +31,7 @@
     _MAX_DESCRIPTION_LENGTH: 200,
 
     events: {
-      'click a.title':    '_changeTitle',
+      'click a.title':    '_changeTitle'
     },
 
     initialize: function() {
@@ -67,7 +67,7 @@
 
       // Display all the visualization info
       this._setName();
-      this.vis.bind('change:name',        this._setName,            this);
+      this.vis.bind('change:name', this._setName, this);
       // Bind model changes
       this.model.bind('change:open', this._setPanelState, this);
 
@@ -77,16 +77,6 @@
 
       cdb.ui.common.TabPane.prototype.initialize.call(this);
     },
-
-    render: function() {
-      var title_template = this.getTemplate('table/views/add_layer');
-      var d = {
-        'title': this.vis.get('name')
-      };
-      this.$el.html(title_template(d));
-      return this;
-    },
-
 
     /**
      *  Set name of the visualization

--- a/lib/assets/javascripts/cartodb/table/actions_menu.js
+++ b/lib/assets/javascripts/cartodb/table/actions_menu.js
@@ -16,6 +16,7 @@
 
     className: 'table_panel',
     animation_time: 300,
+    panel_width: 450,
 
     _TEXTS: {
       saving:         _t('Saving...'),
@@ -85,6 +86,10 @@
 
       cdb.ui.common.TabPane.prototype.initialize.call(this);
     },
+
+    /******
+    ******* Title layer functions *******
+    *******/
 
     /**
      *  Set name of the visualization
@@ -186,9 +191,9 @@
       }
     },
 
-  /*
-  *  Wait function before set new visualization title
-  */
+    /*
+    *  Wait function before set new visualization title
+    */
     _onSetVisAttributes: function(d) {
 
       var old_data = this.vis.toJSON();
@@ -241,6 +246,28 @@
       }
     },
 
+    /* Add title layer functions */
+    _addTitleLayer: function() {
+      this.$('.title_layer').remove();
+
+      var template = this.getTemplate('table/views/add_title_layer');
+      var d = {
+        'title': this.vis.get('name')
+      };
+
+      this.$el.prepend(template(d));
+    },
+
+
+    /******
+    ******* End title layer functions
+    *******/
+
+
+    /******
+    ******* Panel toggling functions *******
+    *******/
+
     /* Add panel toggle button */
     _addToggleButton: function() {
       var template = this.getTemplate('table/views/layer_panel_toggle');
@@ -255,7 +282,88 @@
       this.$el[ this.model.get('open') ? 'addClass' : 'removeClass' ]('opened');
     },
 
-    /* Layer panel functions */
+    // Move right panel
+    movePanel: function() {
+      var mod = this.getActivePane();
+      if (!mod) return false;
+
+      this._hideDropdowns();
+
+      // Get the action type and width
+      // of the active module
+      // var action = { module_event: narrow or show, module_width: 450 (integer) }
+      var active_pane = mod.panels.getActivePane();
+      var action  = active_pane.getModuleAction();
+
+      if (!!this.panelOpen) {
+        // Show panel -> trigger
+        cdb.god.trigger('panel_action', action.type);
+
+        // Set open model attribute as true
+        this.model.set('open', true);
+
+        this.$el.animate({
+          width: action.width,
+          right: 0
+        }, this.animation_time, function() {
+          cdb.god.trigger("end_" + action.type);
+        });
+      }
+    },
+
+
+    _showPanel: function() {
+      //TODO: The toggle button disappears on panel open
+      // Switch toggle arrow
+      this.$('.collapse').addClass('open');
+      this.panelOpen = true;
+
+      // Show panel -> trigger
+      cdb.god.trigger('panel_action', 'show');
+
+      // Set open model attribute as true
+      this.model.set('open', true);
+
+      // Resets toggle button placement
+      this.$('.collapse').css({'right': this.panel_width});
+
+      this.$el.animate({
+        width: this.panel_width,
+        right: 0
+      }, this.animation_time);
+    },
+
+    _hidePanel: function() {
+      // Hide panel -> trigger
+      cdb.god.trigger("panel_action", "hide");
+
+      // Set open model attribute as true
+      this.model.set('open', false);
+
+      this.$el.animate({
+        right: 63 - this.panel_width
+      }, this.animation_time);
+
+      this.$('.collapse').removeClass('open');
+      this.panelOpen = false;
+    },
+
+    _togglePanel: function() {
+      // open/hide panel if toggle button clicked
+      if (!!this.panelOpen) {
+        this._hidePanel();
+      } else {
+        this._showPanel();
+      }
+    },
+
+    /******
+    ******* End panel toggling functions
+    *******/
+
+    /******
+    ******* Layer functions *******
+    *******/
 
     _resetLayers: function() {
       //clean all views
@@ -381,17 +489,6 @@
       }
     },
 
-    /* Add title layer functions */
-    _addTitleLayer: function() {
-      this.$('.title_layer').remove();
-
-      var template = this.getTemplate('table/views/add_title_layer');
-      var d = {
-        'title': this.vis.get('name')
-      };
-      this.$el.prepend(template(d));
-    },
-
     _bindLayerTooltip: function(v) {
       var self = this;
       this._unbindLayerTooltip(v);
@@ -417,6 +514,10 @@
     _hideLayerTooltip: function(v) {
       v && v.$(".info").tipsy("hide")
     },
+
+    /******
+    ******* End Layer functions *******
+    *******/
 
 
     ////////////////////
@@ -642,35 +743,6 @@
       this.movePanel();
     },
 
-    // Move right panel
-    movePanel: function() {
-      var mod = this.getActivePane();
-      if (!mod) return false;
-
-      this._hideDropdowns();
-
-      // Get the action type and width
-      // of the active module
-      // var action = { module_event: narrow or show, module_width: 450 (integer) }
-      var active_pane = mod.panels.getActivePane();
-      var action  = active_pane.getModuleAction();
-
-      if (!!this.panelOpen) {
-        // Show panel -> trigger
-        cdb.god.trigger('panel_action', action.type);
-
-        // Set open model attribute as true
-        this.model.set('open', true);
-
-        this.$el.animate({
-          width: action.width,
-          right: 0
-        }, this.animation_time, function() {
-          cdb.god.trigger("end_" + action.type);
-        });
-      }
-    },
-
     hide: function(modName) {
       // Hide the tab
       var mod = this.getActivePane();
@@ -682,6 +754,11 @@
       cdb.god.trigger("closeDialogs");
       cdb.god.trigger("closeDialogs:color");
 
+    },
+
+    _addMapOptions: function() {
+      var mapOptions = this.getTemplate('table/views/map_options_dropdown');
+      $(".title_layer_contents").append(mapOptions());
     },
 
     // l    -> layer view
@@ -724,54 +801,6 @@
 
       // Manage available layers
       this._manageLayers();
-    },
-
-    _showPanel: function() {
-      var panel_width = 450;
-      // Switch toggle arrow
-      this.$('.collapse').addClass('open');
-      this.panelOpen = true;
-
-      // Show panel -> trigger
-      cdb.god.trigger('panel_action', 'show');
-
-      // Set open model attribute as true
-      this.model.set('open', true);
-
-      // Resets toggle button placement
-      this.$('.collapse').animate({
-        right: panel_width
-      }, this.animation_time);
-
-      this.$el.animate({
-        width: panel_width,
-        right: 0
-      }, this.animation_time);
-    },
-
-    _hidePanel: function() {
-      var panel_width = 450;
-      // Hide panel -> trigger
-      cdb.god.trigger("panel_action", "hide");
-
-      // Set open model attribute as true
-      this.model.set('open', false);
-
-      this.$el.animate({
-        right: 63 - panel_width
-      }, this.animation_time);
-
-      this.$('.collapse').removeClass('open');
-      this.panelOpen = false;
-    },
-
-    _togglePanel: function() {
-      // open/hide panel if toggle button clicked
-      if (!!this.panelOpen) {
-        this._hidePanel();
-      } else {
-        this._showPanel();
-      }
     },
 
     _openDeleteLayerDialog: function(layerView) {

--- a/lib/assets/javascripts/cartodb/table/actions_menu.js
+++ b/lib/assets/javascripts/cartodb/table/actions_menu.js
@@ -33,7 +33,8 @@
     _MAX_DESCRIPTION_LENGTH: 200,
 
     events: {
-      'click .title_label':    '_changeTitle'
+      'click .title_label':    '_changeTitle',
+      'click .collapse':       '_togglePanel',
     },
 
     initialize: function() {
@@ -43,12 +44,12 @@
       this.map = this.vis.map;
       this.user = this.options.user;
       this.globalError = this.options.globalError;
+      this.panelOpen = false;
 
       // View bindings
-      _.bindAll(this, '_changeTitle', '_sortStart', '_sortChange', '_sortBeforeStop', '_sortLayers',
+      _.bindAll(this, '_togglePanel', '_changeTitle', '_sortStart', '_sortChange', '_sortBeforeStop', '_sortLayers',
       '_manageLayers', '_checkResize', '_moveSortTooltip');
 
-      this.map.layers.bind('add',    this._newLayer, this);
       this.map.layers.bind('reset',  this._resetLayers, this);
       this.map.layers.bind('add remove', this._updateLayerPositionLabel, this);
       $(window).bind('resize', this._checkResize);
@@ -69,6 +70,9 @@
 
       // Display visualization title info
       this._setName();
+
+      // Add panel toggle button
+      this._addToggleButton();
 
       // Bind model changes
       this.model.bind('change:open', this._setPanelState, this);
@@ -101,43 +105,45 @@
     _changeTitle: function(e) {
       this.killEvent(e);
 
-      var self = this;
-      var isOwner = this.vis.permission.isOwner(this.options.user);
+      if (!!this.panelOpen) {
+        var self = this;
+        var isOwner = this.vis.permission.isOwner(this.options.user);
 
-      if (this.isVisEditable()) {
-        this.title_dialog && this.title_dialog.clean();
-        cdb.god.trigger("closeDialogs");
+        if (this.isVisEditable()) {
+          this.title_dialog && this.title_dialog.clean();
+          cdb.god.trigger("closeDialogs");
 
-        var title_dialog = this.title_dialog = new cdb.admin.EditTextDialog({
-          initial_value: this.vis.get('name'),
-          template_name: 'table/views/edit_name',
-          clean_on_hide: true,
-          modal_class: 'edit_name_dialog',
-          onResponse: setTitle
-        });
+          var title_dialog = this.title_dialog = new cdb.admin.EditTextDialog({
+            initial_value: this.vis.get('name'),
+            template_name: 'table/views/edit_name',
+            clean_on_hide: true,
+            modal_class: 'edit_name_dialog',
+            onResponse: setTitle
+          });
 
-        cdb.god.bind("closeDialogs", title_dialog.hide, title_dialog);
+          cdb.god.bind("closeDialogs", title_dialog.hide, title_dialog);
 
-        // Set position and show
-        var pos = $(e.target).offset();
-        pos.left -= $(window).scrollLeft();
-        pos.top -= $(window).scrollTop();
-        var w = Math.max($(e.target).width() + 100, 280);
-        title_dialog.showAt(pos.left - 20, pos.top - 10, w);
-      } else {
-        var $el = $(e.target);
-        $el
-          .bind('mouseleave', destroyTipsy)
-          .tipsy({
-            fade:     true,
-            trigger:  'manual',
-            html:     true,
-            title:    function() {
-              var mode = self.isSyncTable() ? 'sync' : 'read-only';
-              return _.template(self._TEXTS.rename[ !isOwner ? 'owner' : 'readonly' ])({ mode: mode });
-            }
-          })
-          .tipsy('show');
+          // Set position and show
+          var pos = $(e.target).offset();
+          pos.left -= $(window).scrollLeft();
+          pos.top -= $(window).scrollTop();
+          var w = Math.max($(e.target).width() + 100, 280);
+          title_dialog.showAt(pos.left - 20, pos.top - 10, w);
+        } else {
+          var $el = $(e.target);
+          $el
+            .bind('mouseleave', destroyTipsy)
+            .tipsy({
+              fade:     true,
+              trigger:  'manual',
+              html:     true,
+              title:    function() {
+                var mode = self.isSyncTable() ? 'sync' : 'read-only';
+                return _.template(self._TEXTS.rename[ !isOwner ? 'owner' : 'readonly' ])({ mode: mode });
+              }
+            })
+            .tipsy('show');
+        }
       }
 
       function destroyTipsy() {
@@ -235,6 +241,14 @@
       }
     },
 
+    /* Add panel toggle button */
+    _addToggleButton: function() {
+      var template = this.getTemplate('table/views/layer_panel_toggle');
+      this.$el.prepend(template());
+      // Set initial right position
+      this.$('.collapse').css({'right': '600px'});
+    },
+
     // Setup panel depending view model state
     _setPanelState: function() {
       // If it is open, add open class
@@ -283,7 +297,6 @@
           globalError: self.options.globalError
         });
 
-        v.bind('toggle',    self._toggle, self);
         v.bind('switchTo',  self._switchTo, self);
         v.bind('delete',    self._openDeleteLayerDialog, self);
         v.bind('show',      self.show, self);
@@ -378,48 +391,6 @@
       };
       this.$el.prepend(template(d));
     },
-
-    /*_addLayerDialog: function(e) {
-      this.killEvent(e);
-
-      if (!this.user.canAddLayerTo(this.map)) {
-        var dlg = new cdb.editor.LimitsReachView({
-          clean_on_hide: true,
-          enter_to_confirm: true,
-          user: this.user
-        });
-        dlg.appendToBody();
-        return;
-      }
-
-      if (this.vis.isVisualization()) {
-        this._createAddLayerDialog();
-      } else {
-        this.createVisDlg = new cdb.editor.CreateVisFirstView({
-          clean_on_hide: true,
-          enter_to_confirm: true,
-          model: this.master_vis,
-          router: window.table_router,
-          title: 'A map is required to add layers',
-          explanation: 'A map is a shareable mix of layers, styles and queries. You can view all your maps in your dashboard.',
-          success: this._createAddLayerDialog.bind(this)
-        });
-        this.createVisDlg.appendToBody();
-      }
-    },*/
-
-/*    _createAddLayerDialog: function() {
-      var model = new cdb.editor.AddLayerModel({}, {
-        vis: this.vis,
-        map: this.map,
-        user: this.user
-      });
-      var dialog = new cdb.editor.AddLayerView({
-        model: model,
-        user: this.user
-      });
-      dialog.appendToBody();
-    },*/
 
     _bindLayerTooltip: function(v) {
       var self = this;
@@ -667,7 +638,6 @@
 
       mod.tabs.activate(modName);
       mod.panels.active(modName);
-
       // Move right panel
       this.movePanel();
     },
@@ -685,37 +655,26 @@
       var active_pane = mod.panels.getActivePane();
       var action  = active_pane.getModuleAction();
 
-      // Show panel -> trigger
-      cdb.god.trigger('panel_action', action.type);
+      if (!!this.panelOpen) {
+        // Show panel -> trigger
+        cdb.god.trigger('panel_action', action.type);
 
-      // Set open model attribute as true
-      this.model.set('open', true);
+        // Set open model attribute as true
+        this.model.set('open', true);
 
-      this.$el.animate({
-        width: action.width,
-        right: 0
-      }, this.animation_time, function() {
-        cdb.god.trigger("end_" + action.type);
-      });
+        this.$el.animate({
+          width: action.width,
+          right: 0
+        }, this.animation_time, function() {
+          cdb.god.trigger("end_" + action.type);
+        });
+      }
     },
 
     hide: function(modName) {
-      var panel_width = this.$el.width();
-
       // Hide the tab
       var mod = this.getActivePane();
-
       this._hideDropdowns();
-
-      // Hide panel -> trigger
-      cdb.god.trigger("panel_action", "hide");
-
-      // Set open model attribute as true
-      this.model.set('open', false);
-
-      this.$el.animate({
-        right: 63 - panel_width
-      }, this.animation_time);
     },
 
     _hideDropdowns: function() {
@@ -767,12 +726,51 @@
       this._manageLayers();
     },
 
-    _toggle: function(modName) {
-      // only hide if we click on active tab
-      if (this.model.get('open') && modName == this.getActivePane().panels.activeTab) {
-        this.hide(modName);
+    _showPanel: function() {
+      var panel_width = 450;
+      // Switch toggle arrow
+      this.$('.collapse').addClass('open');
+      this.panelOpen = true;
+
+      // Show panel -> trigger
+      cdb.god.trigger('panel_action', 'show');
+
+      // Set open model attribute as true
+      this.model.set('open', true);
+
+      // Resets toggle button placement
+      this.$('.collapse').animate({
+        right: panel_width
+      }, this.animation_time);
+
+      this.$el.animate({
+        width: panel_width,
+        right: 0
+      }, this.animation_time);
+    },
+
+    _hidePanel: function() {
+      var panel_width = 450;
+      // Hide panel -> trigger
+      cdb.god.trigger("panel_action", "hide");
+
+      // Set open model attribute as true
+      this.model.set('open', false);
+
+      this.$el.animate({
+        right: 63 - panel_width
+      }, this.animation_time);
+
+      this.$('.collapse').removeClass('open');
+      this.panelOpen = false;
+    },
+
+    _togglePanel: function() {
+      // open/hide panel if toggle button clicked
+      if (!!this.panelOpen) {
+        this._hidePanel();
       } else {
-        this.show(modName);
+        this._showPanel();
       }
     },
 

--- a/lib/assets/javascripts/cartodb/table/actions_menu.js
+++ b/lib/assets/javascripts/cartodb/table/actions_menu.js
@@ -28,8 +28,10 @@
       }
     },
 
+    _MAX_DESCRIPTION_LENGTH: 200,
+
     events: {
-      'click .add_layer': '_addLayerDialog'
+      'click a.title':    '_changeTitle',
     },
 
     initialize: function() {
@@ -41,7 +43,7 @@
       this.globalError = this.options.globalError;
 
       // View bindings
-      _.bindAll(this, '_sortStart', '_sortChange', '_sortBeforeStop', '_sortLayers',
+      _.bindAll(this, '_changeTitle', '_sortStart', '_sortChange', '_sortBeforeStop', '_sortLayers',
       '_manageLayers', '_checkResize', '_moveSortTooltip');
 
       this.map.layers.bind('add',    this._newLayer, this);
@@ -63,6 +65,9 @@
         activeWorkView: 'table'
       });
 
+      // Display all the visualization info
+      this._setName();
+      this.vis.bind('change:name',        this._setName,            this);
       // Bind model changes
       this.model.bind('change:open', this._setPanelState, this);
 
@@ -71,6 +76,135 @@
       this.add_related_model(this.vis);
 
       cdb.ui.common.TabPane.prototype.initialize.call(this);
+    },
+
+    render: function() {
+      var title_template = this.getTemplate('table/views/add_layer');
+      var d = {
+        'title': this.vis.get('name')
+      };
+      this.$el.html(title_template(d));
+      return this;
+    },
+
+
+    /**
+     *  Set name of the visualization
+     */
+    _setName: function() {
+      var $title = this.$('h1 a.title');
+
+      $title
+        [(this.isVisEditable())? 'removeClass' : 'addClass' ]('disabled')
+        .text(this.vis.get('name'));
+
+      document.title = this.vis.get('name') + " | CartoDB";
+    },
+
+    /**
+     *  Change visualization title
+     */
+    _changeTitle: function(e) {
+      this.killEvent(e);
+
+      var self = this;
+      var isOwner = this.vis.permission.isOwner(this.options.user);
+
+      if (this.isVisEditable()) {
+        this.title_dialog && this.title_dialog.clean();
+        cdb.god.trigger("closeDialogs");
+
+        var title_dialog = this.title_dialog = new cdb.admin.EditTextDialog({
+          initial_value: this.vis.get('name'),
+          template_name: 'table/views/edit_name',
+          clean_on_hide: true,
+          modal_class: 'edit_name_dialog',
+          onResponse: setTitle
+        });
+
+        cdb.god.bind("closeDialogs", title_dialog.hide, title_dialog);
+
+        // Set position and show
+        var pos = $(e.target).offset();
+        pos.left -= $(window).scrollLeft();
+        pos.top -= $(window).scrollTop();
+        var w = Math.max($(e.target).width() + 100, 280);
+        title_dialog.showAt(pos.left - 20, pos.top - 10, w);
+      } else {
+        var $el = $(e.target);
+        $el
+          .bind('mouseleave', destroyTipsy)
+          .tipsy({
+            fade:     true,
+            trigger:  'manual',
+            html:     true,
+            title:    function() {
+              var mode = self.isSyncTable() ? 'sync' : 'read-only';
+              return _.template(self._TEXTS.rename[ !isOwner ? 'owner' : 'readonly' ])({ mode: mode });
+            }
+          })
+          .tipsy('show');
+      }
+
+      function destroyTipsy() {
+        var $el = $(this);
+        var tipsy = $el.data('tipsy');
+        if (tipsy) {
+          $el
+            .tipsy('hide')
+            .unbind('mouseleave', destroyTipsy);
+        }
+      }
+
+      function setTitle(val) {
+        if (val !== self.vis.get('name') && val !== '') {
+          // Sanitize description (html and events)
+          var title = cdb.Utils.stripHTML(val,'');
+
+          if (self.vis.isVisualization()) {
+            self._onSetAttributes({ name: title });
+          } else {
+            // close any prev modal if existing
+            if (self.change_confirmation) {
+              self.change_confirmation.clean();
+            }
+            self.change_confirmation = cdb.editor.ViewFactory.createDialogByTemplate('common/dialogs/confirm_rename_dataset');
+
+            // If user confirms, app set the new name
+            self.change_confirmation.ok = function() {
+              self._onSetAttributes({ name: title });
+              if (_.isFunction(this.close)) {
+                this.close();
+              }
+            };
+
+            self.change_confirmation
+              .appendToBody()
+              .open();
+          }
+          self.render();
+        }
+      }
+    },
+
+    /**
+     *  Check if visualization/table is editable
+     *  (Checking if it is visualization and/or data layer is in sql view)
+     */
+    isVisEditable: function() {
+      if (this.vis.isVisualization()) {
+        return true;
+      } else {
+        var table = this.dataLayer && this.dataLayer.table;
+
+        if (!table) {
+          return false;
+        } else if (table && (table.isReadOnly() || !table.permission.isOwner(this.options.user))) {
+          return false;
+        } else {
+          return true;
+        }
+      }
     },
 
     // Setup panel depending view model state
@@ -91,7 +225,7 @@
     },
 
     _addLayers: function(layers) {
-      // Add 'add layer' button first
+      // Add 'title' button first
       this._addLayerAddButton();
 
       // Add layers
@@ -209,12 +343,16 @@
     /* Add layer functions */
 
     _addLayerAddButton: function() {
-      this.$('.add_layer').remove();
+      this.$('a.change-title').remove();
+
       var template = this.getTemplate('table/views/add_layer');
-      this.$el.prepend(template());
+      var d = {
+        'title': this.vis.get('name')
+      };
+      this.$el.prepend(template(d));
     },
 
-    _addLayerDialog: function(e) {
+    /*_addLayerDialog: function(e) {
       this.killEvent(e);
 
       if (!this.user.canAddLayerTo(this.map)) {
@@ -241,9 +379,9 @@
         });
         this.createVisDlg.appendToBody();
       }
-    },
+    },*/
 
-    _createAddLayerDialog: function() {
+/*    _createAddLayerDialog: function() {
       var model = new cdb.editor.AddLayerModel({}, {
         vis: this.vis,
         map: this.map,
@@ -254,7 +392,7 @@
         user: this.user
       });
       dialog.appendToBody();
-    },
+    },*/
 
     _bindLayerTooltip: function(v) {
       var self = this;
@@ -342,7 +480,7 @@
             if (!this.sortTooltip) this._addSortTooltip(e, 'torque');
           }
 
-          this.$('section.add_layer').after(
+          this.$('section.change_title').after(
             $(ui.placeholder)
               .outerHeight(active_height)
               .css('display','block')

--- a/lib/assets/javascripts/cartodb/table/views/add_layer.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/add_layer.jst.ejs
@@ -1,7 +1,0 @@
-<section class="change_title">
-  <div class="left">
-    <a class="info" href="#/change-title">
-      <span class="action"><%- title %></span>
-    </a>
-  </div>
-<section>

--- a/lib/assets/javascripts/cartodb/table/views/add_layer.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/add_layer.jst.ejs
@@ -1,8 +1,7 @@
-<section class="add_layer">
+<section class="change_title">
   <div class="left">
-    <a class="info" href="#/add-layer">
-      <span class="add">+</span>
-      <span class="action">Add layer</span>
+    <a class="info" href="#/change-title">
+      <span class="action"><%- title %></span>
     </a>
   </div>
 <section>

--- a/lib/assets/javascripts/cartodb/table/views/add_title_layer.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/add_title_layer.jst.ejs
@@ -1,0 +1,7 @@
+<section class="title_layer">
+  <div class="left title_label">
+    <a class="info" href="#/change-title">
+      <span class="action title"><%- title %></span>
+    </a>
+  </div>
+<section>

--- a/lib/assets/javascripts/cartodb/table/views/layer_panel_toggle.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/layer_panel_toggle.jst.ejs
@@ -1,0 +1,1 @@
+<div class="collapse"></div>

--- a/lib/assets/javascripts/cartodb/table/views/remove_layers_content.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/remove_layers_content.jst.ejs
@@ -1,0 +1,7 @@
+<section class="remove_layers">
+  <div class="left">
+    <a class="info" href="#/remove-layers">
+      <span class="action">Remove All Layers</span>
+    </a>
+  </div>
+<section>

--- a/lib/assets/javascripts/cartodb/table/views/remove_layers_content.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/remove_layers_content.jst.ejs
@@ -1,7 +1,0 @@
-<section class="remove_layers">
-  <div class="left">
-    <a class="info" href="#/remove-layers">
-      <span class="action">Remove All Layers</span>
-    </a>
-  </div>
-<section>

--- a/lib/assets/test/spec/cartodb/table/actions_menu.spec.js
+++ b/lib/assets/test/spec/cartodb/table/actions_menu.spec.js
@@ -48,21 +48,6 @@ describe("Actions menu", function() {
     expect(_.keys(view.tabs).length).toEqual(2);
   });
 
-  it("should add a layer panel when layers is added to the map", function() {
-    spyOn(view, '_bindLayerTooltip');
-    vis.map.layers.add(new cdb.admin.CartoDBLayer({ table_name: 'test_table_3' }));
-    expect(_.keys(view.tabs).length).toEqual(3);
-    expect(view._bindLayerTooltip).toHaveBeenCalled();
-  });
-
-  it("should set current layer when added a new layer", function() {
-    var layer = new cdb.admin.CartoDBLayer({ table_name: 'test_table_3' });
-    spyOn(view, '_switchTo');
-    vis.map.layers.add(layer);
-    expect(view.map.layers.getLayersByType('CartoDB').length).toBe(3);
-    expect(view._switchTo).toHaveBeenCalled();
-  });
-
   it("should set active layer when active-menu initilizes or layers change", function() {
     spyOn(view, '_setDefaultLayer');
     vis.map.layers.reset([
@@ -81,18 +66,38 @@ describe("Actions menu", function() {
     expect(_.keys(view.tabs).length).toEqual(2);
   });
 
+  it("should not allow title change since panel is closed", function() {
+    $('.title_label').click();
+    expect(cdb.admin.EditTextDialog).not.toHaveBeenCalled();
+  });
+
+  it("should open panel", function() {
+    expect(view.model.get('open')).toEqual(false);
+    expect(view.panelOpen).toEqual(false);
+    $('.collapse').click();
+    expect(view.$el.animate).toHaveBeenCalled();
+    expect(view.model.get('open')).toEqual(true);
+    expect(view.panelOpen).toEqual(true);
+  });
+
+  it("should allow title change since panel is open", function() {
+    var oldName = vis.get('name');
+    view._changeTitle.setTitle('new title');
+    expect(vis.get('name')).not.toEqual(oldName);
+    expect(vis.get('name')).toEqual('new title');
+  });
+
   it("should show", function() {
     spyOn(view.$el, 'animate');
     view.show('table');
     expect(view.$el.animate).toHaveBeenCalled();
-    expect(view.model.get('open')).toEqual(true);
+    expect(view.model.get('open')).toEqual(false);
     expect(view.model.get('activeWorkView')).toEqual('table');
   });
 
   it("should hide", function() {
     spyOn(view.$el, 'animate');
     view.render().hide();
-    expect(view.$el.animate).toHaveBeenCalled();
     expect(view.model.get('open')).toEqual(false);
   });
 
@@ -110,36 +115,10 @@ describe("Actions menu", function() {
     expect(p.setActiveWorkView).toHaveBeenCalledWith('table');
   });
 
-  it("should ask create vis first when vis of type", function() {
-    // can't add more layers to a table
-    var masterVisId = view.master_vis.cid;
-    var visId = view.vis.cid;
-    spyOn(cdb.editor.CreateVisFirstView.prototype, 'initialize').and.callThrough();
-    view.$('.add_layer').click();
-    expect(cdb.editor.CreateVisFirstView.prototype.initialize).toHaveBeenCalled();
-    expect(view.createVisDlg).toBeDefined();
-    expect(view.createVisDlg.model.cid).toBe(masterVisId);
-    expect(view.createVisDlg.model.cid).not.toBe(visId);
-  });
-
-  it("should open new layer modal when vis if of type derived (i.e. map)", function() {
-    vis.set('type', 'derived');
-    spyOn(cdb.editor.AddLayerModel.prototype, 'initialize').and.callThrough();
-    view.$('.add_layer').click();
-    expect(cdb.editor.AddLayerModel.prototype.initialize).toHaveBeenCalled();
-  });
-
   it("should order layers when removes a layer", function() {
     spyOn(view, '_manageLayers');
     var last_layer = view.layer_panels[1];
     last_layer.model.destroy();
-    expect(view._manageLayers).toHaveBeenCalled();
-  });
-
-  it("should order layers when adds a layer", function() {
-    var layer = new cdb.admin.CartoDBLayer({ table_name: 'test_table_3' });
-    spyOn(view, '_manageLayers');
-    vis.map.layers.add(layer);
     expect(view._manageLayers).toHaveBeenCalled();
   });
 
@@ -187,23 +166,6 @@ describe("Actions menu", function() {
         new cdb.admin.CartoDBLayer({ type: 'CartoDB', id: 2, table_name: 'test_table_2' })
       ]);
       vis.set('type', 'derived');
-    });
-
-    it('should show reached limits dialog when user has all the allowed layers for a map', function() {
-      view.$('.add_layer a.info').click();
-      expect(view._createAddLayerDialog).not.toHaveBeenCalled();
-      expect(cdb.editor.CreateVisFirstView.prototype.initialize).not.toHaveBeenCalled();
-      expect(cdb.editor.LimitsReachView.prototype.initialize).toHaveBeenCalled();
-    });
-
-    it('should show reached limits dialog when user has more than the allowed layers for a map', function() {
-      var limits = user.get('limits');
-      limits.max_layers = 1;
-      user.set('limits', limits);
-      view.$('.add_layer a.info').click();
-      expect(view._createAddLayerDialog).not.toHaveBeenCalled();
-      expect(cdb.editor.CreateVisFirstView.prototype.initialize).not.toHaveBeenCalled();
-      expect(cdb.editor.LimitsReachView.prototype.initialize).toHaveBeenCalled();
     });
 
   });

--- a/lib/assets/test/spec/cartodb/table/header/header.spec.js
+++ b/lib/assets/test/spec/cartodb/table/header/header.spec.js
@@ -38,11 +38,7 @@ describe("Table/Visualization Header tests", function() {
               <ul class="actions">\
                 <li><a class="back" href="">Back</a></li>\
                 <li><a class="privacy" href="#/visualize"><i class="privacy-status"></i></a></li>\
-                <li><h1><a href="#/change-title" class="title"></a></h1></li>\
               </ul>\
-              <div class="metadata">\
-                <p><a href="#/edit-metadata">edit metadata…</a></p>\
-              </div>\
             </div>\
             <div class="right">\
               <ul class="options">\
@@ -80,111 +76,6 @@ describe("Table/Visualization Header tests", function() {
     this.header.clean();
     this.$header.remove();
   });
-
-  it("should contain a change title link", function() {
-    expect(this.header.$el.find('.title').length).toBeTruthy();
-  })
-
-  it("should create the title change dialog on click", function(done) {
-    $(this.header.el).find('.title').click();
-
-    var self = this;
-
-    setTimeout(function() {
-      expect(self.header.title_dialog).toBeTruthy();
-      self.header.title_dialog.hide();
-      done();
-    }, 25);
-
-  })
-
-  it("should open a warning dialog when user changes the title", function(done) {
-    $(this.header.el).find('.title').click();
-
-    var self = this;
-
-    setTimeout(function() {
-
-      self.header.title_dialog.$('input').val('example');
-      self.header.title_dialog.$('.ok').click();
-
-      setTimeout(function() {
-        expect(self.header.change_confirmation).toBeTruthy();
-        self.header.title_dialog.clean();
-        self.header.change_confirmation.clean();
-        done();
-      }, 25);
-
-    }, 25);
-
-  })
-
-  it("should not open the warning dialog when user changes the title", function(done) {
-    this.vis.set('type', 'derived');
-    $(this.header.el).find('.title').click();
-    this.header._onSetAttributes = function() {};
-
-    var self = this;
-
-    setTimeout(function() {
-      self.header.title_dialog.$('input').val('example');
-      self.header.title_dialog.$('.ok').click();
-
-      setTimeout(function() {
-        expect(self.header.change_confirmation).toBeFalsy();
-        self.header.title_dialog.clean();
-        done();
-      }, 25);
-
-    }, 25);
-
-  })
-
-  it("should not let the user change the visualization/table name when the table is not writable", function(done) {
-    this.vis.map.layers.last().table.sqlView = {
-      isReadOnly: function() { return true; }
-    }
-    $(this.header.el).find('.title').click();
-
-    var self = this;
-
-    setTimeout(function() {
-      var $title = self.header.$('a.title');
-      expect($title.data('tipsy')).toBeDefined();
-      expect($title.data('tipsy').$tip.is(':visible')).toBeTruthy();
-      expect(self.header.title_dialog).toBeFalsy();
-      done();
-    }, 25);
-
-  });
-
-  it("should not let the user change the visualization/table name when the table is syncable", function(done) {
-    this.vis.map.layers.last().table.synchronization.set({id: 'test', from_external_source: false });
-    $(this.header.el).find('.title').click();
-
-    var self = this;
-
-    setTimeout(function() {
-      expect(self.header.title_dialog).toBeFalsy();
-      done();
-    }, 25);
-
-  })
-
-
-  it("should let the user change the visualization name although the table is syncable", function(done) {
-    this.vis.set('type', 'derived');
-    this.vis.map.layers.last().table.synchronization.set({id: 'test', from_external_source: false });
-    $(this.header.el).find('.title').click();
-
-    var self = this;
-
-    setTimeout(function() {
-      expect(self.header.title_dialog).toBeTruthy();
-      self.header.title_dialog.clean();
-      done();
-    }, 25);
-  })
 
   it("should render sync info when table is synced", function() {
     this.vis.map.layers.last().table.synchronization.set({id: 'test', from_external_source: false });
@@ -243,23 +134,6 @@ describe("Table/Visualization Header tests", function() {
     this.header.setInfo();
     this.header.$('.privacy i').click();
     expect(cdb.editor.ChangePrivacyView.prototype.initialize).toHaveBeenCalled();
-  })
-
-  it("shouldnt allow to edit table when user is not the owner", function() {
-    this.vis.set('derived', false);
-    cartodb_layer.table.permission.owner = this.user;
-    this.header.setInfo();
-    this.header.title_dialog = null;
-    this.header.$('a.title').click();
-    expect(this.header.title_dialog).not.toEqual(null);
-    this.header.title_dialog.clean();
-
-    cartodb_layer.table.permission.owner =  new cdb.admin.User({ id: 'test_not_owner' });
-    this.header.setInfo();
-    this.header.title_dialog = null;
-    this.header.$('a.title').click();
-    expect(this.header.title_dialog).toEqual(null);
-
   })
 
   it("should show visualize button when visualization type is table", function() {


### PR DESCRIPTION
This is my progress so far on #44. Putting it up to PR because the following tasks will just build on it and be more complicated so I'd like to get this in good shape first.

Should accomplish:
- [ ] Move Map Title into separate Map Layer, name should still be editable (p. 2)
- [ ] Move Side-panel down so it is below the top toolbar (using Map Layer card styling) (p. 2)
- [ ] Clicking Map Layer Collapse icon to collapse side panel. When side panel is collapsed, arrow icon should change to point in opposite direction (p. 4)

New bugs:
- [ ] Sliding open the side panel makes the toggle button disappear for a second
- [ ] Little 'share' button on the map slides around

Comments:
The toggle button styling is almost certainly not the final desired. I used a cartodb sprite.
I feel shaky moving into migrating metadata and options into the title tab.

In the process of fixing all the broken tests and writing a few new ones
