### PR TITLE
Feature/data library fdw 2

### DIFF
--- a/app/controllers/api/json/imports_controller.rb
+++ b/app/controllers/api/json/imports_controller.rb
@@ -40,10 +40,13 @@ class Api::Json::ImportsController < Api::ApplicationController
 
         if params[:url].present?
           validate_url!(params.fetch(:url)) unless Rails.env.development? || Rails.env.test?
-          options.merge!(data_source: params.fetch(:url))
+          options[:data_source] = params.fetch(:url)
+        elsif params[:fdw].present?
+          options[:service_name] = 'connector'
+          options[:service_item_id] = params[:fdw]
         elsif params[:remote_visualization_id].present?
           external_source = external_source(params[:remote_visualization_id])
-          options.merge!( { data_source: external_source.import_url.presence } )
+          options[:data_source] = external_source.import_url.presence
         else
           options = @stats_aggregator.timing('upload-or-enqueue') do
             results = file_upload_helper.upload_file_to_storage(params, request, Cartodb.config[:importer]['s3'])

--- a/app/controllers/api/json/synchronizations_controller.rb
+++ b/app/controllers/api/json/synchronizations_controller.rb
@@ -140,8 +140,10 @@ class Api::Json::SynchronizationsController < Api::ApplicationController
   private
 
   def set_external_source
-    @external_source = params[:remote_visualization_id].present? ? 
-                                                get_external_source(params[:remote_visualization_id]) : nil
+    @external_source =
+      if params[:remote_visualization_id].present?
+        get_external_source(params[:remote_visualization_id])
+      end
   end
 
   def setup_member_attributes
@@ -165,10 +167,13 @@ class Api::Json::SynchronizationsController < Api::ApplicationController
     if params[:remote_visualization_id].present?
       member_attributes[:interval] = Carto::ExternalSource::REFRESH_INTERVAL
       external_source = @external_source
-      member_attributes.merge!( {
-        url: external_source.import_url.presence,
-        service_item_id: external_source.import_url.presence
-        } )
+      member_attributes[:url] = external_source.import_url.presence
+      member_attributes[:service_item_id] = external_source.import_url.presence
+    end
+
+    if params[:fdw].present?
+      member_attributes[:service_name] = 'connector'
+      member_attributes[:service_item_id] = params[:fdw]
     end
 
     member_attributes
@@ -194,7 +199,10 @@ class Api::Json::SynchronizationsController < Api::ApplicationController
       create_visualization:   ["true", true].include?(params[:create_vis])
     }
 
-    if params[:remote_visualization_id].present?
+    if params[:fdw].present?
+      options[:service_name] = 'connector'
+      options[:service_item_id] = params[:fdw]
+    elsif params[:remote_visualization_id].present?
       external_source = get_external_source(params[:remote_visualization_id])
       options.merge!( { data_source: external_source.import_url.presence } )
     else

--- a/app/models/fdw_table.rb
+++ b/app/models/fdw_table.rb
@@ -1,0 +1,14 @@
+
+require_relative './table'
+
+class FDWTable < Table
+
+  def before_create
+    # Override to only register the table in the db, should not migrate table or create it
+    self.schema(reload:true)
+    set_table_id
+  rescue => e
+    self.handle_creation_error(e)
+  end
+
+end

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -578,7 +578,16 @@ class Table
         CartoDB::StdoutLogger.info 'Table#after_destroy error', "maybe table #{qualified_table_name} doesn't exist: #{e.inspect}"
       end
       Carto::OverviewsService.new(user_database).delete_overviews qualified_table_name
-      user_database.run(%{DROP TABLE IF EXISTS #{qualified_table_name}})
+      begin
+        user_database.run(%{DROP TABLE IF EXISTS #{qualified_table_name}})
+      rescue => e
+        if e.message.include? "Use DROP VIEW"
+          user_database.run(%{DROP VIEW IF EXISTS #{qualified_table_name}})
+          user_database.run(%{DROP FOREIGN TABLE IF EXISTS #{qualified_remote_table_name}})
+        else
+          raise e
+        end
+      end
     end
   end
 
@@ -1183,7 +1192,7 @@ class Table
     record = owner.in_database.select(:pg_class__oid)
       .from(:pg_class)
       .join_table(:inner, :pg_namespace, :oid => :relnamespace)
-      .where(:relkind => 'r', :nspname => owner.database_schema, :relname => name).first
+      .where(:relkind => ['r', 'f'], :nspname => owner.database_schema, :relname => name).first
     record.nil? ? nil : record[:oid]
   end # get_table_id
 
@@ -1237,6 +1246,11 @@ class Table
 
   def qualified_table_name
     "\"#{owner.database_schema}\".\"#{@user_table.name}\""
+  end
+
+  def qualified_remote_table_name
+    schema_common_data = CartoDB::UserModule::DBService::SCHEMA_COMMON_DATA
+    "\"#{schema_common_data}\".\"#{@user_table.name}\""
   end
 
   def database_schema

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -19,6 +19,7 @@ module CartoDB
       SCHEMA_IMPORTER = 'cdb_importer'.freeze
       SCHEMA_GEOCODING = 'cdb'.freeze
       SCHEMA_CDB_DATASERVICES_API = 'cdb_dataservices_client'.freeze
+      SCHEMA_COMMON_DATA = Cartodb::config[:fdw]['remote_schema'].freeze
       CDB_DATASERVICES_CLIENT_VERSION = '0.2.0'.freeze
 
       def initialize(user)
@@ -194,7 +195,7 @@ module CartoDB
       # Centralized method to provide the (ordered) search_path
       def self.build_search_path(user_schema, quote_user_schema = true)
         quote_char = quote_user_schema ? "\"" : ""
-        "#{quote_char}#{user_schema}#{quote_char}, #{SCHEMA_CARTODB}, #{SCHEMA_CDB_DATASERVICES_API}, #{SCHEMA_PUBLIC}"
+        "#{quote_char}#{user_schema}#{quote_char}, #{SCHEMA_CARTODB}, #{SCHEMA_CDB_DATASERVICES_API}, #{SCHEMA_COMMON_DATA}, #{SCHEMA_PUBLIC}"
       end
 
       def set_database_search_path

--- a/config/app_config.yml.sample
+++ b/config/app_config.yml.sample
@@ -109,6 +109,13 @@ defaults: &defaults
     # base_url: 'https://common-data.cartodb.com'
     format: 'shp'
     generate_every: 86400
+  fdw:
+    host: 'localhost'
+    port: 5432
+    database: ''
+    username: ''
+    password: ''
+    remote_schema: ''
   explore_api:
     username: ''
   reports:

--- a/doc/README.BBG.FDW.md
+++ b/doc/README.BBG.FDW.md
@@ -1,0 +1,52 @@
+# Setup foreign data wrapper data library import for cartodb-org repo
+
+This doc describes the high-level manual configuration steps necessary in a cartodb instance to setup
+foreign data wrapper based data library imports. Some examples of commands to run to get the necessary
+info are provided for reference, but will likely need to be modified based on your particular setup.
+
+### Terminology
+
+Remote server/database: The cartodb instance that hosts the commondata account that your
+cartodb instance will be connecting to
+Local server/database: Your cartodb instance, that holds all of your users and data.
+
+### Setup
+
+Once you have a remote cartodb instance and your local cartodb instance setup with the cartodb-org
+codebase, you'll need to do the following to finish up configuration of the remote data library
+foreign data wrappers:
+
+1. Get the database name and schema of the remote cartodb commondata account, e.g.
+```
+sudo -u postgres psql -d carto_db_development -c "select id, database_name, database_schema from users where username='commondata'";
+```
+
+2. Add an `fdwuser` user to the remote cartodb instance
+```
+sudo -u postgres psql -d "<dbnamefromstep1>" -c "CREATE USER fdwuser WITH ENCRYPTED PASSWORD 'asecurepassword'"
+```
+
+3. Add the new `fdwuser` to the common data cartodb user role so it mirrors its permissions, e.g.
+```
+sudo -u postgres psql -d "<dbnamefromstep1>" -c "GRANT \"development_cartodb_user_<idfromstep1>\" TO fdwuser"
+```
+
+4. Update your local instance's `app_config.yml` to include the proper connection parameters to
+the remote cartodb instance:
+```
+# This config must be added at the top level of the config, and a good place for it is
+# right after the common_data block.
+  fdw:
+    host: 'IP address of remote cartodb instance'
+    port: 5432
+    database: '<database name from step 1>'
+    username: 'fdwuser'
+    password: '<passwordyoucreatedinstep2>'
+```
+
+5. Add an appropriate fdwuser entry to your postgresql pg_hba.conf so that the fdwuser is forced
+to connect via `md5`
+
+6. If in development, update the postgresql.conf listen_addresses config option to be `localhost,192.168.20.100`
+
+7. Restart postgresql, then all cartodb services (web, resque, sqlapi, windshaft)

--- a/lib/assets/javascripts/cartodb/common/background_polling/models/import_model.js
+++ b/lib/assets/javascripts/cartodb/common/background_polling/models/import_model.js
@@ -72,7 +72,7 @@ module.exports = cdb.core.Model.extend({
         type: "remote",
         interval: null,
         remote_visualization_id: data.remote_visualization_id,
-        create_vis: false,
+        fdw: 'driver=postgres;channel=postgres_fdw;table=' + data.value,
         value: data.value
       });
     }

--- a/lib/assets/javascripts/cartodb/dashboard/filters_view.js
+++ b/lib/assets/javascripts/cartodb/dashboard/filters_view.js
@@ -376,9 +376,10 @@ module.exports = cdb.core.View.extend({
     var remoteItem = selectedItems[0];
     var remoteItemTable = remoteItem.get('table');
 
+    var tableName = remoteItem.get('name');
     var d = {
       type: 'remote',
-      value: remoteItem.get('name'),
+      value: tableName,
       remote_visualization_id: remoteItem.get('id'),
       size: remoteItemTable && remoteItemTable.size,
       create_vis: true

--- a/lib/assets/javascripts/cartodb/dashboard/filters_view.js
+++ b/lib/assets/javascripts/cartodb/dashboard/filters_view.js
@@ -94,6 +94,7 @@ module.exports = cdb.core.View.extend({
             isMaps: this.router.model.isMaps(),
             selectedItemsCount: selectedItemsCount,
             isSelectedItemLibrary: this._isSelectedItemLibrary(),
+            isSelectedItemSync: this._isSelectedItemSync(),
             maxLayersByMap: this.user.getMaxLayers(),
             totalShared: changedContentType ? 0 : this.collection.total_shared,
             totalLiked: changedContentType ? 0 : this.collection.total_likes,
@@ -467,6 +468,16 @@ module.exports = cdb.core.View.extend({
     var selectedItems = this._selectedItems();
     if (selectedItems.length === 1 && selectedItems[0].get('type') === "remote") {
       return true;
+    } else {
+      return false;
+    }
+  },
+
+  _isSelectedItemSync: function() {
+    var selectedItems = this._selectedItems();
+    if (selectedItems.length === 1) {
+      var sync = selectedItems[0].get('synchronization');
+      return sync && sync.service_name === 'connector';
     } else {
       return false;
     }

--- a/lib/assets/javascripts/cartodb/dashboard/views/filters.jst.ejs
+++ b/lib/assets/javascripts/cartodb/dashboard/views/filters.jst.ejs
@@ -115,7 +115,7 @@
               </li>
             <% } %>
           <% } %>
-          <% if (!isMaps && canCreateDatasets && selectedItemsCount === 1 && !library && !liked && !isSelectedItemLibrary) { %>
+          <% if (!isMaps && canCreateDatasets && selectedItemsCount === 1 && !library && !liked && !isSelectedItemLibrary && !isSelectedItemSync) { %>
             <li class="Filters-actionsItem">
               <a class="Filters-actionsLink js-duplicate_dataset" href="#/duplicate-dataset">Duplicate dataset</a>
             </li>

--- a/lib/assets/javascripts/cartodb/models/synchronization.js
+++ b/lib/assets/javascripts/cartodb/models/synchronization.js
@@ -56,7 +56,7 @@
       if (c.type === "remote") {
         _.extend(d, {
           remote_visualization_id: c.remote_visualization_id,
-          create_vis: false,
+          fdw: 'driver=postgres;channel=postgres_fdw;table=' + c.value,
           value: c.value
         });
       }

--- a/lib/assets/javascripts/cartodb/table/header/views/options_menu.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/header/views/options_menu.jst.ejs
@@ -15,8 +15,13 @@
           <% } %>
         </a>
       </li>
+      <% if (table.isSync()) { %>
+      <li class="disabled"><a class="small">Duplicate dataset...</a></li>
+      <li class="disabled"><a class="small">Merge with dataset...</a></li>
+      <% } else { %>
       <li><a class="small duplicate_table" href="#/duplicate">Duplicate dataset...</a></li>
       <li><a class="small merge_tables" href="#/merge-tables">Merge with dataset...</a></li>
+      <% } %>
 
       <!-- Change privacy?  -->
       <% if (isLayerOwner) { %>
@@ -30,7 +35,8 @@
     <% } %>
 
     <!-- Sync options  -->
-    <% if (table.isSync() && isLayerOwner) { %>
+    <!-- Now that this uses FDW, we don't ever want to show sync options, as they don't really apply -->
+    <% if (false /*table.isSync() && isLayerOwner*/) { %>
       <li><a href="#/sync-settings" class="small sync_settings">Sync settings...</a></li>
     <% } %>
 

--- a/lib/assets/javascripts/cartodb/table/header/views/sync_info_content.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/header/views/sync_info_content.jst.ejs
@@ -8,15 +8,15 @@
   <li>
     <p>
       <% if (state === "success") { %>
-        Synced <%- ran_at %>.
+        Synced
       <% } else if (state === "syncing") { %>
         Syncing...
       <% } else if (state === "failure") { %>
         Sync failed.
       <% } %>
-      
+
       <% if (state === "success") { %>
-        Next will be <%- run_at %>.
+        <% /* There's no need to add extra text in this case. */ %>
       <% } else if (state === "syncing") { %>
         <% /* There's no need to add extra text in this case. */ %>
       <% } else if (error_code || error_message) { %>
@@ -34,10 +34,4 @@
       <% } %>
     </p>
   </li>
-
-  <% if (state !== "syncing") { %>
-    <li class="separator">
-      <p><a href="#/view-options" class="sync_options">view options</a></p>
-    </li>
-  <% } %>
 </ul>

--- a/lib/cartodb/import_error_codes.rb
+++ b/lib/cartodb/import_error_codes.rb
@@ -134,6 +134,21 @@ module CartoDB
       what_about: "Provided URL can't be resolved to a known server. Maybe that URL is wrong or behind a private network. Please provide a valid, public URL and try again.",
       source: ERROR_SOURCE_USER
     },
+    1500 => {
+      title: 'Connector error',
+      what_about: "The connector used to fetch the resourced failed.",
+      source: ERROR_SOURCE_USER
+    },
+    1501 => {
+      title: 'Connector invalid channel',
+      what_about: "The type of connector you were trying to use is invalid or unsupported",
+      source: ERROR_SOURCE_USER
+    },
+    1502 => {
+      title: 'Connector invalid parameters',
+      what_about: "The connector couldn't be configure because the parameters were not valid.",
+      source: ERROR_SOURCE_USER
+    },
     2001 => {
       title: 'Unable to load data',
       what_about: "We couldn't load data from your file into the database.  Please <a href='mailto:support@cartodb.com?subject=Import load error'>contact us</a> and we will help you to load your data.",

--- a/services/importer/lib/importer/base_connector.rb
+++ b/services/importer/lib/importer/base_connector.rb
@@ -1,0 +1,299 @@
+# encoding: utf-8
+# This is the base connector for foreign data wrapper inputs. Alternate implementations of
+# a connector should override the methods used in run() as necessary. See CDBDataLibraryConnector
+# for an example.
+#
+# This base connector currently implements ODBC, but is untested because I don't have an example
+# setup. It is derived from the PR here: https://github.com/CartoDB/cartodb/pull/7755/files
+#
+# Future TODOs:
+#  - Move ODBC into a separate ODBCConnector, and leave the BaseConnector with null implementations
+#  - Create a ConnectorFactory to detect and automatically instantiate the proper connector based
+#    on the set of params that come in from the DataImport model
+
+require_relative './exceptions'
+
+module CartoDB
+  module Importer2
+    class BaseConnector
+      # Requirements:
+      #   * odbc_fdw extension must be installed in the user database
+
+      # Temptative terminology
+      # * connector channel (ODBC, ...)
+      # * provider          (MySQL, ...)     [driver]
+      # * connection        (database/query) [specific data source]
+
+      class ConnectorError < StandardError
+        attr_reader :channel_name, :user_name
+
+        def initialize(message = 'General error', channel = nil, user = nil)
+          @channel_name  = channel
+          @user_name     = user && user.username
+          message = message.to_s
+          message << " Channel: #{@channel_name}" if @channel_name
+          message << " User: #{@user_name}" if @user_name
+          super(message)
+        end
+      end
+
+      class InvalidChannelError < ConnectorError
+        def initialize(channel, user = nil)
+          super "Invalid channel", channel, user
+        end
+      end
+
+      class InvalidParametersError < ConnectorError
+      end
+
+      attr_reader :results, :log, :job
+      attr_accessor :channel, :stats
+
+      # @param connector_source string
+      #     of the form key1=value1;key2=value2...keyn=valuen
+      #     with keys in accepted_parameters
+      def initialize(connector_source, options = {})
+        @pg_options = options[:pg]
+        @log        = options[:log] || new_logger
+        @job        = options[:job] || new_job(@log, @pg_options)
+        @user       = options[:user]
+
+        @id = @job.id
+        @unique_suffix = @id.delete('-')
+        @conn_str = connector_source
+        extract_params
+        validate_params!
+        @schema = Cartodb::config[:fdw]["remote_schema"] || @user.database_schema
+        @table_name = @params['table'] || @job.table_name
+        @results = []
+        @tracker = nil
+        @stats = {}
+      end
+
+      def channel_name
+        'odbc_fdw'
+      end
+
+      def run(tracker = nil)
+        @tracker = tracker
+        @job.log "Connector #{@conn_str}"
+        # TODO: deal with schemas, org users, etc.,
+        # TODO: logging with CartoDB::Logger
+        @job.log "Running pre-create tasks"
+        run_pre_create
+        @job.log "Creating Server"
+        run_create_server
+        @job.log "Creating user mapping"
+        run_create_user_mapping
+        @job.log "Creating Foreign Table"
+        run_create_foreign_table
+        @job.log "Running post create"
+        run_post_create
+      rescue => error
+        @job.log "Connector Error #{error}"
+        @results.push result_for(@schema, @table_name, error)
+      else
+        @job.log "Connector created table #{@table_name}"
+        @job.log "job schema: #{@schema}"
+        @results.push result_for(@schema, @table_name)
+      ensure
+        run_post_create_ensure
+      end
+
+      def success?
+        results.count(&:success?) > 0
+      end
+
+      def remote_data_updated?
+        # TODO: can we detect if query results have changed?
+        true
+      end
+
+      def tracker
+        @tracker || lambda { |state| state }
+      end
+
+      def visualizations
+        []
+      end
+
+      def warnings
+        []
+      end
+
+      private
+
+      def accepted_parameters
+        %w(dsn driver channel host port database table username password sql_query sql_count)
+      end
+
+      def server_options
+        %w(dsn driver channel host port database)
+      end
+
+      def server_params
+        @params.slice(*server_options)
+      end
+
+      def table_params
+        @params.except(*server_options)
+      end
+
+      PARAM_SEP_TOKENS = {
+        '.eq.' => '=',
+        '.sc.' => ';'
+      }.freeze
+
+      # Parse connection string in @conn_str and extract @params and @columns
+      def extract_params
+        # Convert into hash form: "p=v;..." -> { 'p' => v, ...}
+        conn_params = Hash[
+          @conn_str.split(';').map do |p|
+            param, value = p.split('=').map(&:strip)
+            [param.downcase, value]
+          end
+        ]
+
+        # Decode special tokens for the separator chars used.
+        # (this is to allow its use in parameters such as sql_query)
+        conn_params.each do |key, value|
+          PARAM_SEP_TOKENS.each do |token, symbol|
+            value = value.gsub(token, symbol)
+          end
+          conn_params[key] = value
+        end
+
+        # Extract columns of the result table from the parameters
+        # Column definitions are expected in SQL syntax, e.g.
+        #     columns=id int, name text
+        @columns = conn_params.delete 'columns'
+        @columns = @columns.split(',').map(&:strip) if @columns
+        @params = Cartodb::config[:fdw].merge(conn_params)
+      end
+
+      def validate_params!
+        errors = []
+        if @params['dsn'].blank? &&
+           (@params['driver'].blank? || @params['database'].blank? || @params['table'].blank?)
+          errors << "Missing required parameters"
+        end
+        if @params['channel'].blank? || @params['channel'].casecmp(channel_name) != 0
+          raise InvalidChannelError.new(@params['channel'], @user)
+        end
+        #errors << "Missing columns definition" unless @columns.present?
+        invalid_params = @params.keys - accepted_parameters
+        errors << "Invalid parameters: #{invalid_params * ', '}" if invalid_params.present?
+        raise InvalidParametersError.new(errors * "\n") if errors.present?
+      end
+
+      def connector_name
+        @params['dsn'] || @params['driver']
+      end
+
+      def server_name
+        "connector_#{connector_name}_#{@unique_suffix}"
+      end
+
+      def foreign_table_name
+        "#{server_name}_#{@params['table']}"
+      end
+
+      def run_create_server
+        execute_as_superuser create_server_command
+      end
+
+      def create_server_command
+        options = server_params.map { |k, v| "#{k} '#{v}'" } * ",\n"
+        %{
+          CREATE SERVER #{server_name}
+            FOREIGN DATA WRAPPER #{@params['channel']}
+            OPTIONS (#{options});
+        }
+      end
+
+      def run_create_user_mapping
+        execute_as_superuser create_user_mapping_command
+      end
+
+      def create_user_mapping_command
+        %{
+          CREATE USER MAPPING FOR "#{@user.database_username}" SERVER #{server_name};
+        }
+      end
+
+      def run_create_foreign_table
+        execute_as_superuser create_foreign_table_command
+      end
+
+      def create_foreign_table_command
+        options = table_params.map { |k, v| "#{k} '#{v}'" } * ",\n"
+        %{
+          CREATE FOREIGN TABLE #{foreign_table_name} (#{@columns * ','})
+            SERVER #{server_name}
+            OPTIONS (#{options});
+          GRANT SELECT ON #{foreign_table_name} TO "#{@user.database_username}";
+        }
+      end
+
+      def run_pre_create
+        # NOOP by default
+      end
+
+      def run_post_create
+        qualified_table_name = %{"#{@schema}"."#{@table_name}"}
+        execute "CREATE TABLE #{qualified_table_name} AS SELECT * FROM #{foreign_table_name};"
+      end
+
+      def drop_server_command
+        "DROP SERVER IF EXISTS #{server_name} CASCADE;"
+      end
+
+      def drop_foreign_table_command
+        "DROP FOREIGN TABLE IF EXISTS #{foreign_table_name} CASCADE;"
+      end
+
+      def run_post_create_ensure
+        @log.append_and_store "Connector cleanup"
+        execute_as_superuser drop_foreign_table_command
+        execute_as_superuser drop_server_command
+        @log.append_and_store "Connector cleaned-up"
+      end
+
+      def execute_as_superuser(command)
+        @user.in_database(as: :superuser).execute command
+      end
+
+      def execute(command)
+        @user.in_database.execute command
+      end
+
+      def result_for(schema, table_name, error = nil)
+        @job.success_status = !error
+        @job.logger.store
+        Result.new(
+          name:           @params['table'],
+          schema:         schema,
+          tables:         [table_name],
+          success:        @job.success_status,
+          error_code:     error_for(error),
+          log_trace:      @job.logger.to_s,
+          support_tables: []
+        )
+      end
+
+      def new_logger
+        CartoDB::Log.new(type: CartoDB::Log::TYPE_DATA_IMPORT)
+      end
+
+      def new_job(log, pg_options)
+        Job.new(logger: log, pg_options: pg_options)
+      end
+
+      UNKNOWN_ERROR_CODE = 99999
+
+      def error_for(exception)
+        exception && ERRORS_MAP.fetch(exception.class, UNKNOWN_ERROR_CODE)
+      end
+    end
+  end
+end

--- a/services/importer/lib/importer/base_connector.rb
+++ b/services/importer/lib/importer/base_connector.rb
@@ -268,6 +268,7 @@ module CartoDB
       end
 
       def result_for(schema, table_name, error = nil)
+        print "IMPORTER: RESULT #{schema}, #{table_name}, #{error}\n"
         @job.success_status = !error
         @job.logger.store
         Result.new(

--- a/services/importer/lib/importer/connectors/cdb_data_library_connector.rb
+++ b/services/importer/lib/importer/connectors/cdb_data_library_connector.rb
@@ -1,0 +1,120 @@
+# encoding: utf-8
+# This is a custom connector which replaces standard copy imports in the cartodb data library
+# with a postgresql foreign data wrapper
+#
+# It is configured via an 'fdw' key in the app_config.yml, and the parameters provided there
+# can be overridden in a POST to the imports or synchronizations API
+
+module CartoDB
+  module Importer2
+    class CDBDataLibraryConnector < BaseConnector
+      # Requirements:
+      # postgres_fdw extension must be available in the user database
+
+      def channel_name
+        'postgres_fdw'
+      end
+
+      private
+
+      def accepted_parameters
+        %w(driver channel host port database table username password remote_schema)
+      end
+
+      def server_options
+        %w(host port database)
+      end
+
+      def server_name
+        server_string = [server_params['host'],
+                         server_params['port'],
+                         server_params['database']].join(';')
+        server_hash = Digest::SHA1.hexdigest server_string
+        "connector_#{channel_name}_#{server_hash}"
+      end
+
+      def foreign_table_name
+        @params['table']
+      end
+
+      def run_pre_create
+        run_create_extension
+        run_create_schema
+      end
+
+      def run_create_server
+        server_count = execute_as_superuser %{SELECT * from pg_foreign_server WHERE srvname = '#{server_name}'}
+        if server_count == 0
+          execute_as_superuser create_server_command
+        end
+      end
+
+      def run_create_extension
+        execute_as_superuser %{ CREATE EXTENSION IF NOT EXISTS #{channel_name} }
+      end
+
+      def run_create_schema
+        execute_as_superuser %{ CREATE SCHEMA IF NOT EXISTS "#{@schema}" }
+        execute_as_superuser %{ GRANT CREATE,USAGE ON SCHEMA "#{@schema}" TO postgres }
+        execute_as_superuser %{ GRANT CREATE,USAGE ON SCHEMA "#{@schema}" TO "#{@user.database_username}" }
+        execute_as_superuser %{ GRANT USAGE ON SCHEMA "#{@schema}" TO publicuser }
+      end
+
+      def create_server_command
+        %{
+          CREATE SERVER #{server_name}
+            FOREIGN DATA WRAPPER #{@params['channel']}
+            OPTIONS (
+              host '#{server_params['host']}',
+              dbname '#{server_params['database']}',
+              port '#{server_params['port']}'
+            )
+        }
+      end
+
+      def run_create_user_mapping
+        for usename in [@user.database_username, 'postgres']
+          user_mapping_count = execute_as_superuser %{
+            SELECT *
+            FROM pg_user_mappings
+            WHERE srvname = '#{server_name}' AND usename = '#{usename}'
+          }
+          if user_mapping_count == 0
+            execute_as_superuser %{
+              CREATE USER MAPPING FOR "#{usename}" SERVER #{server_name}
+                OPTIONS ( user '#{@params['username']}', password '#{@params['password']}');
+            }
+          end
+        end
+      end
+
+      def create_foreign_table_command
+        %{
+          IMPORT FOREIGN SCHEMA #{@schema} LIMIT TO (#{foreign_table_name})
+            FROM SERVER #{server_name} INTO #{@schema};
+          ALTER FOREIGN TABLE #{@schema}.#{foreign_table_name} OWNER TO "#{@user.database_username}";
+          GRANT SELECT ON #{@schema}.#{foreign_table_name} TO publicuser;
+          CREATE VIEW #{@user.database_schema}.#{foreign_table_name} AS SELECT * FROM #{@schema}.#{foreign_table_name};
+        }
+      end
+
+      def run_post_create
+        # Ensure here that the remote cdb_tablemetadata are imported
+        begin
+          execute_as_superuser %{select '#{@schema}.cdb_tablemetadata'::regclass}
+        rescue => e
+          execute_as_superuser %{
+            CREATE FOREIGN TABLE #{@schema}.cdb_tablemetadata (tabname text, updated_at timestamp with time zone)
+              SERVER #{server_name}
+              OPTIONS (table_name 'cdb_tablemetadata_text', schema_name 'cartodb', updatable 'false');
+            GRANT SELECT ON #{@schema}.cdb_tablemetadata TO publicuser;
+          }
+        end
+      end
+
+      def run_post_create_ensure
+        # NOOP
+      end
+    end
+  end
+end

--- a/services/importer/lib/importer/exceptions.rb
+++ b/services/importer/lib/importer/exceptions.rb
@@ -1,6 +1,7 @@
 # encoding: utf-8
 
 require_relative '../../../../services/datasources/lib/datasources/exceptions'
+require_relative './base_connector'
 
 module CartoDB
   module Importer2
@@ -167,7 +168,10 @@ module CartoDB
       CartoDB::Datasources::GNIPServiceError                      => 1009,
       CartoDB::Datasources::DropboxPermissionError                => 1016,
       CartoDB::Datasources::BoxPermissionError                    => 1021,
-      CartoDB::Datasources::GDriveNoExternalAppsAllowedError      => 1008
+      CartoDB::Datasources::GDriveNoExternalAppsAllowedError      => 1008,
+      CartoDB::Importer2::BaseConnector::ConnectorError               => 1500,
+      CartoDB::Importer2::BaseConnector::InvalidChannelError          => 1501,
+      CartoDB::Importer2::BaseConnector::InvalidParametersError       => 1502
     }
   end
 end

--- a/vendor/assets/javascripts/cartodb.mod.odyssey.uncompressed.js
+++ b/vendor/assets/javascripts/cartodb.mod.odyssey.uncompressed.js
@@ -1,5 +1,5 @@
 // version: 3.15.9
-// sha: 5bee7c8c6c6b2a62ec29c598f9c4331a9cb831fb
+// sha: a2b8834622f2b4d3b849a7e810cff998d982844d
 
 !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.O=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
 


### PR DESCRIPTION
This is a WIP, will need to be rebased down. But it works with some manual configuration.

TODO:
- [x] Cleanup trigger method in UI
- [x] Disable duplicate dataset option when using an FDW sync table
- [ ] ~~(deferring) Combine fdw and remote_visualization_id params in synchronizations/dataimport API endpoint~~
- [x] A round of code cleanup and documentation of the base/cdb_data_library connectors after review
- [x] Remove all PRINT statements
- [x] Rebase
- [x] ~~Update with new commit from cartodb-org/cartodb-postgresql#1~~

Manual ops configuration steps (described in a bit more detail in the README in this PR):
- Move commondata user to custom schema via `bundle exec rake cartodb:db:move_user_to_schema['commondata_username']
- Create a `fdwuser` with some encrypted password on the foreign server
- GRANT commondata cdb user TO fdwuser on foreign server
- Add fdwuser role to pg_hba.conf with custom rule to force md5 password auth for all connections
- Add fdw configuration based on environment to app_config.yml
