### PR TITLE
Convert Map/Data switch to toggle button

### DIFF
--- a/app/assets/stylesheets/editor/table_overrides.css.scss
+++ b/app/assets/stylesheets/editor/table_overrides.css.scss
@@ -21,6 +21,9 @@ div.vis_navigation nav a.tab {
   padding-bottom: 3px;
   font-weight: $sFontWeight-bold
 }
+div.vis_navigation nav .hidden {
+  display: none !important;
+}
 
 div.table table tbody tr td div.cell,
 div.map .option-button,

--- a/app/views/admin/shared/_vis_header.html.erb
+++ b/app/views/admin/shared/_vis_header.html.erb
@@ -6,7 +6,7 @@
       <div class="vis_navigation">
         <nav>
           <%= link_to "Map",  "#/map",   :class => "smaller strong tab" %>
-          <%= link_to "Data", "#/table", :class => "smaller strong tab hidden" %>
+          <%= link_to "Table", "#/table", :class => "smaller strong tab hidden" %>
 
         </nav>
       </div>

--- a/app/views/admin/shared/_vis_header.html.erb
+++ b/app/views/admin/shared/_vis_header.html.erb
@@ -5,8 +5,8 @@
 
       <div class="vis_navigation">
         <nav>
-          <%= link_to "Map",  "#/map",   :class => "smaller strong tab selected" %>
-          <%= link_to "Data", "#/table", :class => "smaller strong tab" %>
+          <%= link_to "Map",  "#/map",   :class => "smaller strong tab" %>
+          <%= link_to "Data", "#/table", :class => "smaller strong tab hidden" %>
 
         </nav>
       </div>
@@ -34,4 +34,3 @@
     <div class="globalerror"></div>
   </div>
 </header>
-

--- a/lib/assets/javascripts/cartodb/old_common/tabs.js
+++ b/lib/assets/javascripts/cartodb/old_common/tabs.js
@@ -8,15 +8,16 @@ cdb.admin.Tabs = cdb.core.View.extend({
     initialize: function() {
       _.bindAll(this, 'activate');
       this.preventDefault = false;
+      this.activeClass = 'selected';
     },
 
     activate: function(name) {
-      this.$('a').removeClass('selected');
-      this.$('a[href$="#'+ ((this.options.slash) ? '/' : '') + name + '"]').addClass('selected');
+      this.$('a').removeClass(this.activeClass);
+      this.$('a[href$="#'+ ((this.options.slash) ? '/' : '') + name + '"]').addClass(this.activeClass);
     },
 
     desactivate: function(name) {
-      this.$('a[href$="#' + ((this.options.slash) ? '/' : '') + name + '"]').removeClass('selected');
+      this.$('a[href$="#' + ((this.options.slash) ? '/' : '') + name + '"]').removeClass(this.activeClass);
     },
 
     disable: function(name) {

--- a/lib/assets/javascripts/cartodb/table/table.js
+++ b/lib/assets/javascripts/cartodb/table/table.js
@@ -173,6 +173,7 @@ $(function() {
         el: this.$('nav'),
         slash: true
       });
+      this.tabs.activeClass = 'hidden'
       this.addView(this.tabs);
 
       // *** work pane (table and map)


### PR DESCRIPTION
In the map view, rather than showing both Map and Data as separate options, we hide the currently selected option and only show a button to go to the alternate interface. This additionally renames "Data" to "Table"
