### PR TITLE
Move buttons according to export adjustments specification

### DIFF
--- a/lib/assets/javascripts/cartodb/old_common/header.js
+++ b/lib/assets/javascripts/cartodb/old_common/header.js
@@ -29,6 +29,7 @@ cdb.admin.Header = cdb.core.View.extend({
       created:      _t('Visualization created')
     },
     share: {
+      export:        _t('EXPORT'),
       publish:        _t('PUBLISH'),
       visualize:    _t('VISUALIZE')
     },
@@ -133,12 +134,7 @@ cdb.admin.Header = cdb.core.View.extend({
 
     var view;
     if (this.model.isVisualization()) {
-      view = new cdb.editor.PublishView({
-        clean_on_hide: true,
-        enter_to_confirm: true,
-        user: this.options.user,
-        model: this.model // vis
-      });
+      alert('export');
     } else {
       view = new cdb.editor.CreateVisFirstView({
         clean_on_hide: true,
@@ -148,8 +144,8 @@ cdb.admin.Header = cdb.core.View.extend({
         title: 'A map is required to publish',
         explanation: 'A map is a shareable mix of layers, styles and queries. You can view all your maps in your dashboard.'
       });
+      view.appendToBody();
     }
-    view.appendToBody();
   },
 
   _showPrivacyDialog: function(e) {
@@ -325,7 +321,7 @@ cdb.admin.Header = cdb.core.View.extend({
     var is_visualization = this.model.isVisualization();
 
     if (is_visualization) {
-      $share.find("span").text(this._TEXTS.share.publish);
+      $share.find("span").text(this._TEXTS.share.export);
       this._setPrivacy();
       var route = cdb.config.prefixUrl() + "/dashboard/maps";
       $back.attr("href", route );

--- a/lib/assets/javascripts/cartodb/old_common/header.js
+++ b/lib/assets/javascripts/cartodb/old_common/header.js
@@ -30,7 +30,6 @@ cdb.admin.Header = cdb.core.View.extend({
     },
     share: {
       export:        _t('EXPORT'),
-      publish:        _t('PUBLISH'),
       visualize:    _t('VISUALIZE')
     },
     share_privacy: {

--- a/lib/assets/javascripts/cartodb/table/header/options_menu.js
+++ b/lib/assets/javascripts/cartodb/table/header/options_menu.js
@@ -34,7 +34,8 @@ cdb.admin.HeaderOptionsMenu = cdb.admin.DropdownMenu.extend({
     'click .merge_tables':    '_mergeTables',
     'click .change_privacy':  '_changePrivacy',
     'click .sync_settings':   '_syncSettings',
-    'click .delete_vis':      '_deleteItem'
+    'click .delete_vis':      '_deleteItem',
+    'click .export_vis':      '_exportVis'
   },
 
   render: function() {
@@ -256,6 +257,29 @@ cdb.admin.HeaderOptionsMenu = cdb.admin.DropdownMenu.extend({
       clean_on_hide: true,
       enter_to_confirm: true
     });
+    view.appendToBody();
+  },
+
+  _exportVis: function(e) {
+    var view;
+    if (this.model.isVisualization()) {
+      view = new cdb.editor.PublishView({
+        clean_on_hide: true,
+        enter_to_confirm: true,
+        user: this.options.user,
+        model: this.model
+      });
+    } else {
+      view = new cdb.editor.CreateVisFirstView({
+        clean_on_hide: true,
+        enter_to_confirm: true,
+        model: this.model,
+        router: window.table_router,
+        title: 'A map is required to publish',
+        explanation: 'A map is a shareable mix of layers, styles and queries. You can view all' +
+                     'your maps in your dashboard.'
+      });
+    }
     view.appendToBody();
   }
 });

--- a/lib/assets/javascripts/cartodb/table/header/views/options_menu.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/header/views/options_menu.jst.ejs
@@ -25,9 +25,12 @@
         <% } else { %>
           <li class="disabled"><a class="small">Change privacy...</a></li>
         <% } %>
+
       <% } %>
 
     <% } %>
+
+
 
     <!-- Sync options  -->
     <% if (table.isSync() && isLayerOwner) { %>
@@ -65,6 +68,9 @@
 
     <!-- Map options  -->
     <li><a class="small duplicate_vis" href="#/duplicate">Duplicate map</a></li>
+
+    <li><a class="small export_vis" href="#/duplicate_vis">Get Link</a></li>
+
     <% if (isVisOwner) { %>
       <li><a class="small change_privacy" href="#/change-privacy">Change privacy</a></li>
       <li><a class="small lock_vis" href="#/lock-vis">Lock map</a></li>

--- a/vendor/assets/javascripts/cartodb.mod.odyssey.uncompressed.js
+++ b/vendor/assets/javascripts/cartodb.mod.odyssey.uncompressed.js
@@ -1,5 +1,5 @@
 // version: 3.15.9
-// sha: b308a025d124af7b11144a95adf9bca8e47b7176
+// sha: 3415ddd07ee8b6c04237025cc8a1d164192ae5a8
 
 !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.O=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
 

--- a/vendor/assets/javascripts/cartodb.uncompressed.js
+++ b/vendor/assets/javascripts/cartodb.uncompressed.js
@@ -1,6 +1,6 @@
 // cartodb.js version: 3.15.9
 // uncompressed version: cartodb.uncompressed.js
-// sha: b308a025d124af7b11144a95adf9bca8e47b7176
+// sha: a2b8834622f2b4d3b849a7e810cff998d982844d
 (function() {
   var define;  // Undefine define (require.js), see https://github.com/CartoDB/cartodb.js/issues/543
   var root = this;
@@ -33318,6 +33318,8 @@ cdb.ui.common.FullScreen = cdb.core.View.extend({
 
 cdb.geo.ui.InsetMap = cdb.core.View.extend({
 
+  ANIMATION_DURATION_MS: 150,
+
   AIMING_RECT_OPTIONS: {
     color: '#000000',
     weight: 1,
@@ -33413,7 +33415,7 @@ cdb.geo.ui.InsetMap = cdb.core.View.extend({
     // TODO: No access to DEFAULT_BASEMAPS in cartodb.js. Used a static url for now,
     // consider other options, or maybe we can just remove this fallback?
     // var positron = cdb.admin.DEFAULT_BASEMAPS.CartoDB[0];
-    var positron = {url: ''};
+    var positron = {url: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png'};
     var url = baseLayer.get('url') || baseLayer.get('urlTemplate') || positron.url;
     var config = _.extend({}, positron, baseLayer);
     return new L.TileLayer(url, config);
@@ -33447,9 +33449,9 @@ cdb.geo.ui.InsetMap = cdb.core.View.extend({
     var x = this.model.get('x');
     var position = this.model.get('xPosition');
     if (position === 'left') {
-      this.$control.animate({ left: x }, 150);
+      this.$control.animate({ left: x }, this.ANIMATION_DURATION_MS);
     } else {
-      this.$control.animate({ right: x }, 150);
+      this.$control.animate({ right: x }, this.ANIMATION_DURATION_MS);
     }
 
     this.trigger('change_x', this);
@@ -33463,9 +33465,9 @@ cdb.geo.ui.InsetMap = cdb.core.View.extend({
     var y = this.model.get('y');
     var position = this.model.get('yPosition');
     if (position === 'top') {
-      this.$control.animate({ top: y }, 150);
+      this.$control.animate({ top: y }, this.ANIMATION_DURATION_MS);
     } else {
-      this.$control.animate({ bottom: y }, 150);
+      this.$control.animate({ bottom: y }, this.ANIMATION_DURATION_MS);
     }
 
     this.trigger('change_y', this);
@@ -33501,7 +33503,7 @@ cdb.geo.ui.InsetMap = cdb.core.View.extend({
 
   render: function () {
     // Don't attach to this.$el because then the inset map element ends up outside the
-    //  leaflet-controls container which causes trouble
+    // leaflet-controls container which causes trouble
 
     if (!this.miniMapControl) {
       return this;


### PR DESCRIPTION
Still TODO:
- Move code to start image export process from `cdb.admin.MapTap._exportImage` into the placeholder in `cdb.admin.Header`
- Remove "Export Image" button from map toolbar
