### PR TITLE
Implement new export button

### DIFF
--- a/lib/assets/javascripts/cartodb/old_common/header.js
+++ b/lib/assets/javascripts/cartodb/old_common/header.js
@@ -133,7 +133,7 @@ cdb.admin.Header = cdb.core.View.extend({
 
     var view;
     if (this.model.isVisualization()) {
-      alert('export');
+      cdb.god.trigger('export_image_clicked', e);
     } else {
       view = new cdb.editor.CreateVisFirstView({
         clean_on_hide: true,

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -196,7 +196,6 @@ cdb.admin.MapTab = cdb.core.View.extend({
     'click .toggle_slides.button': '_toggleSlides',
     'click .add_overlay.button':   'killEvent',
     'click .canvas_setup.button':  'killEvent',
-    'click .export_image.button':  '_exportImageClick',
     'click .sqlview .clearview':   '_clearView',
     'click .sqlview .export_query':'_tableFromQuery',
     'click .sqlview .dismiss':'_dismissSQLView',
@@ -305,6 +304,9 @@ cdb.admin.MapTab = cdb.core.View.extend({
 
     _.bindAll(this, 'showNoGeoRefWarning', "_exportImage");
 
+    cdb.god.bind("export_image_clicked", function(e) {
+      this._exportImageClick(e);
+    }, this);
   },
 
   _addLegendBindings: function () {
@@ -1343,8 +1345,6 @@ cdb.admin.MapTab = cdb.core.View.extend({
   },
 
   _exportImageClick: function(e) {
-    this.killEvent(e);
-
     if (this.exportBar) {
       this._removeExportBar();
     }

--- a/lib/assets/javascripts/cartodb/table/views/maptab.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/maptab.jst.ejs
@@ -30,13 +30,7 @@
     </li>
 
     <% if (exportEnabled) { %>
-      <li class="button export_image">
-        <a href="#" class="thumb"></a>
-        <div class="info">
-          <h5>Export</h5>
-          <strong class="name">Image</strong>
-        </div>
-      </li>
+
     <% } %>
 
     <% } else { %>

--- a/vendor/assets/javascripts/cartodb.mod.odyssey.uncompressed.js
+++ b/vendor/assets/javascripts/cartodb.mod.odyssey.uncompressed.js
@@ -1,5 +1,5 @@
 // version: 3.15.9
-// sha: 3415ddd07ee8b6c04237025cc8a1d164192ae5a8
+// sha: b308a025d124af7b11144a95adf9bca8e47b7176
 
 !function(e){if("object"==typeof exports&&"undefined"!=typeof module)module.exports=e();else if("function"==typeof define&&define.amd)define([],e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.O=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
 

--- a/vendor/assets/javascripts/cartodb.uncompressed.js
+++ b/vendor/assets/javascripts/cartodb.uncompressed.js
@@ -1,6 +1,6 @@
 // cartodb.js version: 3.15.9
 // uncompressed version: cartodb.uncompressed.js
-// sha: a2b8834622f2b4d3b849a7e810cff998d982844d
+// sha: b308a025d124af7b11144a95adf9bca8e47b7176
 (function() {
   var define;  // Undefine define (require.js), see https://github.com/CartoDB/cartodb.js/issues/543
   var root = this;
@@ -33318,8 +33318,6 @@ cdb.ui.common.FullScreen = cdb.core.View.extend({
 
 cdb.geo.ui.InsetMap = cdb.core.View.extend({
 
-  ANIMATION_DURATION_MS: 150,
-
   AIMING_RECT_OPTIONS: {
     color: '#000000',
     weight: 1,
@@ -33415,7 +33413,7 @@ cdb.geo.ui.InsetMap = cdb.core.View.extend({
     // TODO: No access to DEFAULT_BASEMAPS in cartodb.js. Used a static url for now,
     // consider other options, or maybe we can just remove this fallback?
     // var positron = cdb.admin.DEFAULT_BASEMAPS.CartoDB[0];
-    var positron = {url: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png'};
+    var positron = {url: ''};
     var url = baseLayer.get('url') || baseLayer.get('urlTemplate') || positron.url;
     var config = _.extend({}, positron, baseLayer);
     return new L.TileLayer(url, config);
@@ -33449,9 +33447,9 @@ cdb.geo.ui.InsetMap = cdb.core.View.extend({
     var x = this.model.get('x');
     var position = this.model.get('xPosition');
     if (position === 'left') {
-      this.$control.animate({ left: x }, this.ANIMATION_DURATION_MS);
+      this.$control.animate({ left: x }, 150);
     } else {
-      this.$control.animate({ right: x }, this.ANIMATION_DURATION_MS);
+      this.$control.animate({ right: x }, 150);
     }
 
     this.trigger('change_x', this);
@@ -33465,9 +33463,9 @@ cdb.geo.ui.InsetMap = cdb.core.View.extend({
     var y = this.model.get('y');
     var position = this.model.get('yPosition');
     if (position === 'top') {
-      this.$control.animate({ top: y }, this.ANIMATION_DURATION_MS);
+      this.$control.animate({ top: y }, 150);
     } else {
-      this.$control.animate({ bottom: y }, this.ANIMATION_DURATION_MS);
+      this.$control.animate({ bottom: y }, 150);
     }
 
     this.trigger('change_y', this);
@@ -33503,7 +33501,7 @@ cdb.geo.ui.InsetMap = cdb.core.View.extend({
 
   render: function () {
     // Don't attach to this.$el because then the inset map element ends up outside the
-    // leaflet-controls container which causes trouble
+    //  leaflet-controls container which causes trouble
 
     if (!this.miniMapControl) {
       return this;


### PR DESCRIPTION
Remove "Export Image" button from map toolbar.
"Export" button on top right now performs this action.
