### PR TITLE
Copy foreign table vis on CDBDataLibraryConnector import

### DIFF
--- a/services/importer/lib/importer/connectors/cdb_data_library_connector.rb
+++ b/services/importer/lib/importer/connectors/cdb_data_library_connector.rb
@@ -15,6 +15,10 @@ module CartoDB
         'postgres_fdw'
       end
 
+      def foreign_table_name
+        @params['table']
+      end
+
       private
 
       def accepted_parameters
@@ -31,10 +35,6 @@ module CartoDB
                          server_params['database']].join(';')
         server_hash = Digest::SHA1.hexdigest server_string
         "connector_#{channel_name}_#{server_hash}"
-      end
-
-      def foreign_table_name
-        @params['table']
       end
 
       def run_pre_create


### PR DESCRIPTION
Requires the Cartodb.config[:common_data] key in app_config.yml to correctly
point to the remote Cartodb instance to copy data from.

If remote vis copy fails for some reason, it does not crash the import.

At the moment, this metadata copy only works from the 'Connect Dataset' link in the Data Library view of the datasets dashboard. The other ways to import a remote dataset involve an extra 'create map' step in the UI where that visualization stomps any created by the data importer. There's also a few additional interactions via those import workflows that I don't think were thought through.

@javisantana can you mention anyone else that should take a look at this?

Starting with this in the common data account:
![screen shot 2016-07-05 at 15 42 17](https://cloud.githubusercontent.com/assets/1818302/16597568/a3c643a6-42c7-11e6-80e4-1265ba619dda.png)

Yields this after importing in a local account:
![screen shot 2016-07-05 at 15 47 16](https://cloud.githubusercontent.com/assets/1818302/16597596/cc4df972-42c7-11e6-9f46-729ae2348ede.png)
