### PR TITLE
Move annotate dropdown to header

### DIFF
--- a/app/assets/stylesheets/map/map.css.scss
+++ b/app/assets/stylesheets/map/map.css.scss
@@ -22,7 +22,7 @@ div.map {
 }
 
 div.map, .mobile_bkg {
-  padding: 84px 84px 20px 20px;
+  padding: 20px 20px 20px 20px;
 }
 
 div.map.animated .cartodb-map {
@@ -447,7 +447,7 @@ div.map {
 
   &.derived div.cartodb-map {
 
-    @include position(82px, 79px, 15px, 15px);
+    @include position(15px, 79px, 15px, 15px);
     @include border-radius(3px);
     @include size(auto);
 

--- a/app/assets/stylesheets/map/map.css.scss
+++ b/app/assets/stylesheets/map/map.css.scss
@@ -22,7 +22,7 @@ div.map {
 }
 
 div.map, .mobile_bkg {
-  padding: 20px 20px 20px 20px;
+  padding: 84px 84px 20px 20px;
 }
 
 div.map.animated .cartodb-map {
@@ -447,7 +447,7 @@ div.map {
 
   &.derived div.cartodb-map {
 
-    @include position(15px, 79px, 15px, 15px);
+    @include position(82px, 79px, 15px, 15px);
     @include border-radius(3px);
     @include size(auto);
 

--- a/app/assets/stylesheets/old_elements/dropdown.css.scss
+++ b/app/assets/stylesheets/old_elements/dropdown.css.scss
@@ -17,6 +17,17 @@
     border:none;
     @include box-shadow(rgba(0,0,0,0.2) 0 0 4px 1px);
     z-index:50;
+    min-width: 200px;
+
+    a {
+      color: #2483B4;
+      font-weight: 500;
+      text-decoration: none;
+      &:hover {
+        text-decoration: underline;
+        color: #333;
+      }
+    }
 
     &:before {
       content:' ';

--- a/app/assets/stylesheets/table/header/header_content.css.scss
+++ b/app/assets/stylesheets/table/header/header_content.css.scss
@@ -155,7 +155,7 @@
       height:45px;
       margin:0;
 
-      li { margin:0; }
+      li { margin:7px; }
 
       .privacy {
 

--- a/app/assets/stylesheets/table/header/header_navigation.css.scss
+++ b/app/assets/stylesheets/table/header/header_navigation.css.scss
@@ -12,17 +12,6 @@
 
   // Navigation block
   div.vis_navigation {
-    position:absolute;
-    $width: 300px;
-    width: $width;
-    top: 4px;
-    left:50%;
-    margin-left: -$width/2;
-    padding:0;
-    text-align:center;
-
-    z-index: 100;
-
     nav {
       position:relative;
       @include inline-block();

--- a/app/views/admin/shared/_vis_header.html.erb
+++ b/app/views/admin/shared/_vis_header.html.erb
@@ -3,18 +3,22 @@
 
     <div class="header_content">
 
-      <div class="vis_navigation">
-        <nav>
-          <%= link_to "Map",  "#/map",   :class => "smaller strong tab" %>
-          <%= link_to "Table", "#/table", :class => "smaller strong tab hidden" %>
 
-        </nav>
-      </div>
 
       <div class="left">
         <ul class="actions">
-          <li><%= link_to "Back", CartoDB.path(self, 'root'), :class => "back" %></li>
           <li><a class="privacy" href="#/visualize"><i class="privacy-status"></i></a></li>
+          <li><form>
+              <input type="text" />
+              <input type="submit" />
+          </li></form>
+          <li><a class="dropdown add_overlay button" href="#">Annotate</a></li>
+          <li><div class="vis_navigation">
+            <nav>
+              <%= link_to "Map",  "#/map",   :class => "smaller strong tab" %>
+              <%= link_to "Table", "#/table", :class => "smaller strong tab hidden" %>
+            </nav>
+          </div></li>
         </ul>
       </div>
 

--- a/lib/assets/javascripts/cartodb/old_common/header.js
+++ b/lib/assets/javascripts/cartodb/old_common/header.js
@@ -62,7 +62,6 @@ cdb.admin.Header = cdb.core.View.extend({
 
     // Display all the visualization info
     this.setInfo();
-    this.setupOverlays();
   },
 
   // Set new dataLayer from the current layerView
@@ -345,7 +344,7 @@ cdb.admin.Header = cdb.core.View.extend({
 
   },
 
-  clearMap: function() {
+  clearDropdown: function() {
     if (this.overlaysDropdown) {
       this.overlaysDropdown.clean();
       delete this.overlaysDropdown;
@@ -356,10 +355,17 @@ cdb.admin.Header = cdb.core.View.extend({
     var type = this.visualization.get("type");
 
     if (type !== "table") {
+    }
+  },
+
+  toggleOverlaysDropdown: function(tab) {
+    $(".add_overlay").toggleClass('disabled', tab === "table");
+
+    if (tab !== "table") {
       this._addOverlaysDropdown();
     } else {
-      // Disable the overlays dropdown button
-      $(".add_overlay").addClass('disabled');
+      this.clearDropdown();
+      //$(".add_overlay .widgets_dropdown").remove();
     }
   },
 

--- a/lib/assets/javascripts/cartodb/old_common/header.js
+++ b/lib/assets/javascripts/cartodb/old_common/header.js
@@ -54,8 +54,7 @@ cdb.admin.Header = cdb.core.View.extend({
     this.$body = $('body');
     this.dataLayer = null;
     this.globalError = this.options.globalError;
-    this.canvas = this.options.canvas;
-    this.mapView = this.options.mapView;
+    this.mapTab = this.options.mapTab;
     this.visualization = this.options.visualization;
     this._initBinds();
 
@@ -311,14 +310,15 @@ cdb.admin.Header = cdb.core.View.extend({
     }
   },
 
-  _addOverlaysDropdown: function() {
+  addOverlaysDropdown: function() {
+    $(".add_overlay").removeClass('disabled');
 
     if (!this.overlaysDropdown) {
 
       this.overlaysDropdown = new cdb.admin.OverlaysDropdown({
         vis: this.model,
-        canvas: this.canvas,
-        mapView: this.mapView,
+        canvas: this.mapTab.getCanvas(),
+        mapView: this.mapTab.getMapView(),
         target: $('.add_overlay'),
         position: "position",
         collection: this.visualization.overlays,
@@ -345,6 +345,8 @@ cdb.admin.Header = cdb.core.View.extend({
   },
 
   clearDropdown: function() {
+    $(".add_overlay").addClass('disabled');
+
     if (this.overlaysDropdown) {
       this.overlaysDropdown.clean();
       delete this.overlaysDropdown;
@@ -362,7 +364,7 @@ cdb.admin.Header = cdb.core.View.extend({
     $(".add_overlay").toggleClass('disabled', tab === "table");
 
     if (tab !== "table") {
-      this._addOverlaysDropdown();
+      this.addOverlaysDropdown();
     } else {
       this.clearDropdown();
       //$(".add_overlay .widgets_dropdown").remove();

--- a/lib/assets/javascripts/cartodb/old_common/header.js
+++ b/lib/assets/javascripts/cartodb/old_common/header.js
@@ -43,7 +43,8 @@ cdb.admin.Header = cdb.core.View.extend({
     'click a.options':      '_openOptionsMenu',
     'click a.share':        '_shareVisualization',
     'click a.privacy':      '_showPrivacyDialog',
-    'click header nav a':   '_onTabClick'
+    'click header nav a':   '_onTabClick',
+    'click .add_overlay.button': 'killEvent'
   },
 
   initialize: function(options) {
@@ -53,10 +54,15 @@ cdb.admin.Header = cdb.core.View.extend({
     this.$body = $('body');
     this.dataLayer = null;
     this.globalError = this.options.globalError;
+    this.canvas = this.options.canvas;
+    this.mapView = this.options.mapView;
+    this.visualization = this.options.visualization;
     this._initBinds();
+
 
     // Display all the visualization info
     this.setInfo();
+    this.setupOverlays();
   },
 
   // Set new dataLayer from the current layerView
@@ -306,6 +312,58 @@ cdb.admin.Header = cdb.core.View.extend({
     }
   },
 
+  _addOverlaysDropdown: function() {
+
+    if (!this.overlaysDropdown) {
+
+      this.overlaysDropdown = new cdb.admin.OverlaysDropdown({
+        vis: this.model,
+        canvas: this.canvas,
+        mapView: this.mapView,
+        target: $('.add_overlay'),
+        position: "position",
+        collection: this.visualization.overlays,
+        template_base: "table/views/widget_dropdown",
+        tick: "left",
+        horizontal_position: "left",
+        horizontal_offset: "40px"
+      });
+
+      this.addView(this.overlaysDropdown);
+
+      this.overlaysDropdown.bind("onOverlayDropdownOpen", function(){
+        this.slidesPanel && this.slidesPanel.hide();
+        this.exportImageView && this.exportImageView.hide();
+      }, this);
+
+
+      cdb.god.bind("closeDialogs", this.overlaysDropdown.hide, this.overlaysDropdown);
+      cdb.god.bind("closeOverlayDropdown", this.overlaysDropdown.hide, this.overlaysDropdown);
+
+      $(".add_overlay").append(this.overlaysDropdown.render().el);
+    }
+
+  },
+
+  clearMap: function() {
+    if (this.overlaysDropdown) {
+      this.overlaysDropdown.clean();
+      delete this.overlaysDropdown;
+    }
+  },
+
+  setupOverlays: function() {
+    var type = this.visualization.get("type");
+
+    if (type !== "table") {
+      this._addOverlaysDropdown();
+    } else {
+      // Disable the overlays dropdown button
+      $(".add_overlay").addClass('disabled');
+    }
+  },
+
+
   /**
    *  Wait function before set new visualization attributes
    */
@@ -410,4 +468,5 @@ cdb.admin.Header = cdb.core.View.extend({
     e.preventDefault();
     window.table_router.navigate(this._generateTableUrl(e), {trigger: true});
   }
+
 });

--- a/lib/assets/javascripts/cartodb/public_table/table_public.js
+++ b/lib/assets/javascripts/cartodb/public_table/table_public.js
@@ -181,14 +181,11 @@
         self.model.set('bounds', options.bounds);
       });
 
-      this.mapView = this.mapTab.getMapView();
-
       // Navigation
       this.header = new cdb.open.PublicHeader({
         el: this.$('.navigation'),
         model: this.table,
-        canvas: this.canvas,
-        mapView: this.mapView,
+        mapTab: this.mapTab,
         user: this.user,
         belong_organization: belong_organization,
         config: this.options.config

--- a/lib/assets/javascripts/cartodb/public_table/table_public.js
+++ b/lib/assets/javascripts/cartodb/public_table/table_public.js
@@ -69,16 +69,6 @@
         this.authenticated_user.fetch();
       }
 
-      // Navigation
-      this.header = new cdb.open.PublicHeader({
-        el: this.$('.navigation'),
-        model: this.table,
-        user: this.user,
-        belong_organization: belong_organization,
-        config: this.options.config
-      });
-      this.addView(this.header);
-
       // Likes
       var like = new cdb.open.LikeView({
         el: this.$el.find(".extra_options .js-like"),
@@ -135,10 +125,14 @@
         user_name: this.options.user_name
       });
 
+      // Define the canvas here so it can be provided to Header and MapTab
+      this.canvas  = new cdb.core.Model({ mode: "desktop" });
+
       // Map tab
       this.mapTab = new cdb.open.PublicMapTab({
         vizjson: this.options.vizjson,
         auth_token: this.options.auth_token,
+        canvas: this.canvas,
         https: this.options.https,
         vizjson_url: this.options.vizjson_url,
         model: new cdb.core.Model({
@@ -164,6 +158,7 @@
       this.mapTabMobile = new cdb.open.PublicMapTab({
         vizjson: this.options.vizjson,
         auth_token: this.options.auth_token,
+        canvas: this.canvas,
         https: this.options.https,
         vizjson_url: this.options.vizjson_url,
         model: new cdb.core.Model({
@@ -185,6 +180,20 @@
       this.mapTabMobile.bind('boundsChanged', function(options) {
         self.model.set('bounds', options.bounds);
       });
+
+      this.mapView = this.mapTab.getMapView();
+
+      // Navigation
+      this.header = new cdb.open.PublicHeader({
+        el: this.$('.navigation'),
+        model: this.table,
+        canvas: this.canvas,
+        mapView: this.mapView,
+        user: this.user,
+        belong_organization: belong_organization,
+        config: this.options.config
+      });
+      this.addView(this.header);
 
       this.workViewMobile.addTab('table', this.tableTabMobile.render());
       this.workViewMobile.addTab('map', this.mapTabMobile.render());

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -351,7 +351,9 @@ cdb.admin.MapTab = cdb.core.View.extend({
 
     clearTimeout(this.autoSaveBoundsTimer);
 
-    this.mapView.clean();
+    if (this.mapView) {
+      this.mapView.clean();
+    }
 
     if (this.exportBar) {
       this._removeExportBar(false);
@@ -579,6 +581,8 @@ cdb.admin.MapTab = cdb.core.View.extend({
     if (this.activeLayerView) {
       this._bindDataLayer(this.activeLayerView, this.activeLayerView.model);
     }
+
+    this.trigger('mapViewReady');
 
   },
 
@@ -867,10 +871,11 @@ cdb.admin.MapTab = cdb.core.View.extend({
   },
 
   getMapView: function() {
-    if (!this.mapView) {
-      this.switchMapType();
-    }
     return this.mapView;
+  },
+
+  getCanvas: function() {
+    return this.canvas;
   },
 
   _onKeyDown: function(e) {

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -266,8 +266,7 @@ cdb.admin.MapTab = cdb.core.View.extend({
     this.user = this.options.user;
     this.vis  = this.options.vis;
     this.master_vis  = this.options.master_vis;
-
-    this.canvas  = new cdb.core.Model({ mode: "desktop" });
+    this.canvas = this.options.canvas;
 
     this.map_enabled     = false;
     this.georeferenced   = false;
@@ -359,8 +358,7 @@ cdb.admin.MapTab = cdb.core.View.extend({
     }
 
     this._removeExportImageView();
-
-    if (this.overlaysDropdown)        this.overlaysDropdown.clean();
+    
     if (this.basemapDropdown)         this.basemapDropdown.clean();
 
     if (this.zoom) {
@@ -396,7 +394,6 @@ cdb.admin.MapTab = cdb.core.View.extend({
 
     delete this.mapToolbar;
     delete this.mapView;
-    delete this.overlaysDropdown;
     delete this.basemapDropdown;
 
     delete this.zoom;
@@ -524,7 +521,6 @@ cdb.admin.MapTab = cdb.core.View.extend({
 
       if (type !== "table") {
 
-        this._addOverlaysDropdown();
         this.canvas.on("change:mode", this._onChangeCanvasMode, this);
 
       }
@@ -582,39 +578,6 @@ cdb.admin.MapTab = cdb.core.View.extend({
 
     if (this.activeLayerView) {
       this._bindDataLayer(this.activeLayerView, this.activeLayerView.model);
-    }
-
-  },
-
-  _addOverlaysDropdown: function() {
-
-    if (!this.overlaysDropdown) {
-
-      this.overlaysDropdown = new cdb.admin.OverlaysDropdown({
-        vis: this.master_vis,
-        canvas: this.canvas,
-        mapView: this.mapView,
-        target: $('.add_overlay'),
-        position: "position",
-        collection: this.vis.overlays,
-        template_base: "table/views/widget_dropdown",
-        tick: "left",
-        horizontal_position: "left",
-        horizontal_offset: "40px"
-      });
-
-      this.addView(this.overlaysDropdown);
-
-      this.overlaysDropdown.bind("onOverlayDropdownOpen", function(){
-        this.slidesPanel && this.slidesPanel.hide();
-        this.exportImageView && this.exportImageView.hide();
-      }, this);
-
-
-      cdb.god.bind("closeDialogs", this.overlaysDropdown.hide, this.overlaysDropdown);
-      cdb.god.bind("closeOverlayDropdown", this.overlaysDropdown.hide, this.overlaysDropdown);
-
-      $(".add_overlay").append(this.overlaysDropdown.render().el);
     }
 
   },
@@ -901,6 +864,13 @@ cdb.admin.MapTab = cdb.core.View.extend({
       return layerModel.get("type") === 'CartoDB'
     });
 
+  },
+
+  getMapView: function() {
+    if (!this.mapView) {
+      this.switchMapType();
+    }
+    return this.mapView;
   },
 
   _onKeyDown: function(e) {

--- a/lib/assets/javascripts/cartodb/table/table.js
+++ b/lib/assets/javascripts/cartodb/table/table.js
@@ -333,6 +333,7 @@ $(function() {
 
       this.workView.bind('tabEnabled:map', this.mapTab.enableMap, this.mapTab);
       this.workView.bind('tabEnabled', this.tabs.activate);
+      this.workView.bind('tabEnabled', this.header.toggleOverlaysDropdown, this.header);
       this.mapTab.bind('missingClick', self.menu.hide, self.menu);
 
       this.workView.addTab('table', this.tableTab.render(), { active: false });

--- a/lib/assets/javascripts/cartodb/table/table.js
+++ b/lib/assets/javascripts/cartodb/table/table.js
@@ -296,8 +296,7 @@ $(function() {
         globalError: this.globalError,
         model: this.master_vis,
         visualization: this.vis,
-        canvas: canvas,
-        mapView: this.mapTab.getMapView(),
+        mapTab: this.mapTab,
         user: this.user,
         config: this.options.config,
         geocoder: this.geocoder,
@@ -333,7 +332,8 @@ $(function() {
 
       this.workView.bind('tabEnabled:map', this.mapTab.enableMap, this.mapTab);
       this.workView.bind('tabEnabled', this.tabs.activate);
-      this.workView.bind('tabEnabled', this.header.toggleOverlaysDropdown, this.header);
+      this.workView.bind('tabEnabled:table', this.header.clearDropdown, this.header);
+      this.mapTab.bind('mapViewReady', this.header.addOverlaysDropdown, this.header);
       this.mapTab.bind('missingClick', self.menu.hide, self.menu);
 
       this.workView.addTab('table', this.tableTab.render(), { active: false });

--- a/lib/assets/javascripts/cartodb/table/table.js
+++ b/lib/assets/javascripts/cartodb/table/table.js
@@ -273,12 +273,31 @@ $(function() {
       // TODO: remove when new_modals is enabled for everybody
       this.geocoder = new cdb.admin.Geocoding();
 
+      // Define the canvas here so it can be provided to Header and MapTab
+      var canvas  = new cdb.core.Model({ mode: "desktop" });
+
+      // Map tab
+      this.mapTab = new cdb.admin.MapTab({
+        model: this.map,
+        baseLayers: this.baseLayers,
+        vis: this.vis,
+        canvas: canvas,
+        master_vis: this.master_vis,
+        geocoder: this.geocoder,
+        backgroundPollingModel: this.backgroundPollingModel,
+        table: this.table,
+        user: this.user,
+        menu: this.menu
+      });
+
       // New visualization header
       this.header = new cdb.admin.Header({
         el: this.$('header'),
         globalError: this.globalError,
         model: this.master_vis,
         visualization: this.vis,
+        canvas: canvas,
+        mapView: this.mapTab.getMapView(),
         user: this.user,
         config: this.options.config,
         geocoder: this.geocoder,
@@ -295,19 +314,6 @@ $(function() {
         geocoder: this.geocoder,
         backgroundPollingModel: this.backgroundPollingModel,
         globalError: this.globalError,
-        menu: this.menu
-      });
-
-      // Map tab
-      this.mapTab = new cdb.admin.MapTab({
-        model: this.map,
-        baseLayers: this.baseLayers,
-        vis: this.vis,
-        master_vis: this.master_vis,
-        geocoder: this.geocoder,
-        backgroundPollingModel: this.backgroundPollingModel,
-        table: this.table,
-        user: this.user,
         menu: this.menu
       });
 

--- a/lib/assets/javascripts/cartodb/table/views/maptab.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/maptab.jst.ejs
@@ -13,14 +13,6 @@
         </li>
     <% } %>
 
-    <li class="button add_overlay">
-      <a href="#" class="thumb"></a>
-      <div class="info">
-        <h5>Add</h5>
-        <strong class="name">Element</strong>
-      </div>
-    </li>
-
     <% if (exportEnabled) { %>
 
     <% } %>

--- a/lib/assets/javascripts/cartodb/table/views/maptab.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/maptab.jst.ejs
@@ -1,35 +1,3 @@
-<div class="map_toolbar">
-  <ul class="options">
-
-    <% if (type != 'table') { %>
-
-    <% if (slides_enabled) { %>
-        <li class="button toggle_slides">
-          <a href="#" class="thumb"></a>
-          <div class="info">
-            <h5>Create</h5>
-            <strong class="name">Slides</strong>
-          </div>
-        </li>
-    <% } %>
-
-    <% if (exportEnabled) { %>
-
-    <% } %>
-
-    <% } else { %>
-
-    <li class="dropdown basemap_dropdown">
-      <a href="#" class="thumb"></a>
-      <div class="info">
-        <h5>Basemap</h5>
-        <strong class="name">Change basemap</strong>
-      </div>
-    </li>
-
-    <% } %>
-
-  </ul>
-</div>
+<!-- <div class="map_toolbar"></div> -->
 
 <div class="cartodb-map"></div>

--- a/lib/assets/javascripts/cartodb/table/views/maptab.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/maptab.jst.ejs
@@ -1,3 +1,35 @@
-<!-- <div class="map_toolbar"></div> -->
+<div class="map_toolbar">
+  <ul class="options">
+
+    <% if (type != 'table') { %>
+
+    <% if (slides_enabled) { %>
+        <li class="button toggle_slides">
+          <a href="#" class="thumb"></a>
+          <div class="info">
+            <h5>Create</h5>
+            <strong class="name">Slides</strong>
+          </div>
+        </li>
+    <% } %>
+
+    <% if (exportEnabled) { %>
+
+    <% } %>
+
+    <% } else { %>
+
+    <li class="dropdown basemap_dropdown">
+      <a href="#" class="thumb"></a>
+      <div class="info">
+        <h5>Basemap</h5>
+        <strong class="name">Change basemap</strong>
+      </div>
+    </li>
+
+    <% } %>
+
+  </ul>
+</div>
 
 <div class="cartodb-map"></div>


### PR DESCRIPTION
This moves the Annotate dropdown to the header, as well as removes the Back arrow icon on the right and does some minor adjustments to the header. This does not completely remove the toolbar from the Map page, as that's likely going to be connected with the PR that implements the drop-down of the rich text editor controls.
