### PR TITLE
Export locally without showing modal

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.js
@@ -88,7 +88,21 @@ module.exports = BaseDialog.extend({
       })
     );
     this._panes.active('result');
+
     this.trigger('finish', this);
+
+    /*
+     * The following is a bit of a hack that "clicks" on the link to cause the
+     * browser to "download" the base64 data URI.
+     *
+     * Also considered was setting window.location and using window.open,
+     * which resulted in the web page being replaced with the image,
+     * not a downloaded file.
+     */
+    if (!this.avmm) {
+      document.getElementById('download_link').click();
+      this.close();
+    }
   },
 
   _initBinds: function() {

--- a/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.jst.ejs
@@ -5,7 +5,9 @@
     </div>
     <p class="Dialog-headerTitle">Your image has been generated correctly</p>
     <% if (response.type === 'url') {%>
-    <p class="Dialog-headerText">It's now available in: <a href="<%- response.content %>" target="_blank" class="ExportImageResult--url" download="<%- response.filename %>"><%- response.displayedLink %></a></p>
+    <p class="Dialog-headerText">It's now available in: <a href="<%- response.content %>"
+        id="download_link"
+        target="_blank" class="ExportImageResult--url" download="<%- response.filename %>"><%- response.displayedLink %></a></p>
     <% } else { %>
     <p class="Dialog-headerText">To embed it in your website, use the code below</p>
   </div>


### PR DESCRIPTION
As noted in the comments:

``` javascript
    /*
     * The following is a bit of a hack that "clicks" on the link to cause the
     * browser to "download" the base64 data URI.
     *
     * Also considered was setting window.location and using window.open,
     * which resulted in the web page being replaced with the image,
     * not a downloaded file.
     */
```
