### PR TITLE
Bugfix legend disappears when changing export view size

### DIFF
--- a/lib/assets/javascripts/cartodb/table/export_image_view.js
+++ b/lib/assets/javascripts/cartodb/table/export_image_view.js
@@ -467,7 +467,6 @@ cdb.admin.ExportImageView = cdb.core.View.extend({
 
   _cancel: function(e) {
     this.killEvent(e);
-    this._showOverlays();
     this.hide();
   },
 
@@ -478,6 +477,7 @@ cdb.admin.ExportImageView = cdb.core.View.extend({
   },
 
   clean: function() {
+    this._showOverlays();
     $(document).unbind('keydown', this._keydown);
     $(window).off("resize", this._onResizeWindow);
     this.elder('clean');


### PR DESCRIPTION
And when export view is cancelled.

Delays the call to _showOverlays so that it happens only
when we are about to completely destroy the ExportImageView
