### PR TITLE
Filter by geographic boundary

### DIFF
--- a/app/assets/images/sprites/leaflet-spritesheet.svg
+++ b/app/assets/images/sprites/leaflet-spritesheet.svg
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 540 60" height="60" width="540">
+    <g id="enabled" fill="#464646">
+        <g id="polyline">
+            <path d="M18 36v6h6v-6h-6zm4 4h-2v-2h2v2z"/>
+            <path d="M36 18v6h6v-6h-6zm4 4h-2v-2h2v2z"/>
+            <path d="M23.142 39.145l-2.285-2.29 16-15.998 2.285 2.285z"/>
+        </g>
+        <path id="polygon" d="M100 24.565l-2.096 14.83L83.07 42 76 28.773 86.463 18z"/>
+        <path id="rectangle" d="M140 20h20v20h-20z"/>
+        <path id="circle" d="M221 30c0 6.078-4.926 11-11 11s-11-4.922-11-11c0-6.074 4.926-11 11-11s11 4.926 11 11z"/>
+        <path id="marker" d="M270,19c-4.971,0-9,4.029-9,9c0,4.971,5.001,12,9,14c4.001-2,9-9.029,9-14C279,23.029,274.971,19,270,19z M270,31.5c-2.484,0-4.5-2.014-4.5-4.5c0-2.484,2.016-4.5,4.5-4.5c2.485,0,4.5,2.016,4.5,4.5C274.5,29.486,272.485,31.5,270,31.5z"/>
+        <g id="edit">
+            <path d="M337,30.156v0.407v5.604c0,1.658-1.344,3-3,3h-10c-1.655,0-3-1.342-3-3v-10c0-1.657,1.345-3,3-3h6.345 l3.19-3.17H324c-3.313,0-6,2.687-6,6v10c0,3.313,2.687,6,6,6h10c3.314,0,6-2.687,6-6v-8.809L337,30.156"/>
+            <path d="M338.72 24.637l-8.892 8.892H327V30.7l8.89-8.89z"/>
+            <path d="M338.697 17.826h4v4h-4z" transform="rotate(-134.99 340.703 19.817)"/>
+        </g>
+        <g id="remove">
+            <path d="M381 42h18V24h-18v18zm14-16h2v14h-2V26zm-4 0h2v14h-2V26zm-4 0h2v14h-2V26zm-4 0h2v14h-2V26z"/>
+            <path d="M395 20v-4h-10v4h-6v2h22v-2h-6zm-2 0h-6v-2h6v2z"/>
+        </g>
+    </g>
+    <g id="disabled" fill="#bbb" transform="translate(120)">
+        <use xlink:href="#edit" id="edit-disabled"/>
+        <use xlink:href="#remove" id="remove-disabled"/>
+    </g>
+</svg>

--- a/app/assets/stylesheets/map/leaflet.css.scss
+++ b/app/assets/stylesheets/map/leaflet.css.scss
@@ -245,15 +245,15 @@
 	border: 5px solid #bbb;
 	}
 
-.leaflet-draw-section {
+.leaflet-draw {
 	position: relative;
-	top: 110px;
-	left: 58px;
+	top: 250px;
+	left: 11px;
 
 	.leaflet-draw-toolbar {
-		width: 28px;
 
 		a {
+            width: 28px;
 			background-image: url('/assets/3.23.57/images/sprites/leaflet-spritesheet.svg');
 			background-size: 270px 30px;
 			background-repeat: no-repeat;

--- a/app/assets/stylesheets/map/leaflet.css.scss
+++ b/app/assets/stylesheets/map/leaflet.css.scss
@@ -245,6 +245,33 @@
 	border: 5px solid #bbb;
 	}
 
+.leaflet-draw-section {
+	position: relative;
+	top: 110px;
+	left: 58px;
+
+	.leaflet-draw-toolbar {
+		width: 28px;
+
+		a {
+			background-image: url('/assets/3.23.57/images/sprites/leaflet-spritesheet.svg');
+			background-size: 270px 30px;
+			background-repeat: no-repeat;
+		}
+
+	 .leaflet-draw-draw-polygon {
+			background-position: -31px -2px;
+		}
+
+		.leaflet-draw-draw-rectangle {
+			background-position: -62px -2px;
+		}
+
+		.leaflet-draw-draw-circle {
+			background-position: -92px -2px;
+		}
+	}
+}
 
 /* Zoom and fade animations */
 

--- a/lib/assets/javascripts/cartodb/models/filter.js
+++ b/lib/assets/javascripts/cartodb/models/filter.js
@@ -306,18 +306,18 @@ cdb.admin.models.FilterDiscrete = cdb.core.Model.extend({
       this.trigger('change:items', this, this.items);
     }, this);
 
-    this.operations.bind('change', function() {
-      this.trigger('change', this)
-      this.trigger('change:operations', this, this.operations);
-    }, this);
-    this.operations.bind('add', function () {
-      this.trigger('add', this);
-      this.trigger('add:operations', this, this.operations);
-    }, this);
-    this.operations.bind('remove', function () {
-      this.trigger('remove', this);
-      this.trigger('remove:operations', this, this.operations);
-    }, this);
+    var events = [
+      'change',
+      'add',
+      'remove',
+      'reset'
+    ];
+    _.each(events, (function(event) {
+      this.operations.bind(event, function() {
+        this.trigger(event, this)
+        this.trigger(event + ':operations', this, this.operations);
+      }, this);
+    }).bind(this));
 
     this._fetchHist();
 
@@ -451,7 +451,8 @@ cdb.admin.models.FilterDiscrete = cdb.core.Model.extend({
       'BEGINSWITH': "<%= column %> ILIKE '<%= text %>%'",
       'ENDSWITH': "<%= column %> ILIKE '%<%= text %>'",
       'CONTAINS': "<%= column %> ILIKE '%<%= text %>%'",
-      'EQUALS': "<%= column %> = '<%= text %>'"
+      'EQUALS': "<%= column %> = '<%= text %>'",
+      'INTERSECTS': "ST_Intersects(ST_SetSRID(ST_GeomFromGeoJSON('<%= text %>'), 4326), <%= column %>)"
     };
 
     // If the user entered text…

--- a/lib/assets/javascripts/cartodb/table/layer_panel_view.js
+++ b/lib/assets/javascripts/cartodb/table/layer_panel_view.js
@@ -242,6 +242,11 @@
         return;
       }
 
+      var shape = e.layer;
+      if (e.layerType == "circle") {
+        shape = circle2Poly(shape);
+      }
+
       var filter = this.filters.filters.where({column: 'the_geom'});
       if (filter.length) {
         filter = filter[0]
@@ -258,9 +263,37 @@
       var m = new cdb.admin.models.CategoricalOperation({
         operator: 'AND',
         operation: 'INTERSECTS',
-        text: JSON.stringify(e.layer.toGeoJSON().geometry)
+        text: JSON.stringify(shape.toGeoJSON().geometry)
       });
       filter.operations.reset([m]);
+
+
+      function circle2Poly(circle) {
+        // Code based on http://gis.stackexchange.com/a/127123
+        var d2r = Math.PI / 180; // degrees to radians
+        var r2d = 180 / Math.PI; // radians to degrees
+        var earthsradius = 6371000; // 6371000 is the radius of the earth in meters
+        var points = 20;
+
+        var latlng = circle.getLatLng();
+        var lat = latlng.lat,
+            lng = latlng.lng,
+            radius = circle.getRadius();
+
+        // find the radius in lat/lon
+        var rlat = (radius / earthsradius) * r2d;
+        var rlng = rlat / Math.cos(lat * d2r);
+
+        var list = [];
+        for (var i=0; i < points; i++) {
+          var theta = Math.PI * (i / (points/2));
+          ex = lng + (rlng * Math.cos(theta)); // center a + radius x * cos(theta)
+          ey = lat + (rlat * Math.sin(theta)); // center b + radius y * sin(theta)
+          list.push(new L.LatLng(ey, ex));
+        }
+
+        return new L.Polygon(list);
+      }
     },
 
     // Remove this view and the map layer

--- a/lib/assets/javascripts/cartodb/table/layer_panel_view.js
+++ b/lib/assets/javascripts/cartodb/table/layer_panel_view.js
@@ -239,7 +239,6 @@
 
     _addPolygonFilter: function(e) {
       if( this.dataLayer.get('type') !== 'CartoDB' ) {
-        console.log("Skipping layer because it doesn't have filters");
         return;
       }
 
@@ -249,6 +248,7 @@
       } else {
         filter = new cdb.admin.models.FilterDiscrete({
             table: this.table,
+            column_type: this.table.getColumnType('the_geom'),
             column: 'the_geom',
             list_view: false
           });

--- a/lib/assets/javascripts/cartodb/table/layer_panel_view.js
+++ b/lib/assets/javascripts/cartodb/table/layer_panel_view.js
@@ -215,7 +215,6 @@
 
     deactivated: function() {
       this.clearSubViews();
-      this._removeButtons();
       this.view_model.set('state', 'idle');
     },
 

--- a/lib/assets/javascripts/cartodb/table/layer_panel_view.js
+++ b/lib/assets/javascripts/cartodb/table/layer_panel_view.js
@@ -211,11 +211,14 @@
       this.setActivePanelView();
 
       this.panels.bind('tabEnabled', this.saveActivePanelView, this);
+      cdb.god.bind('add:polygon_filter', this._addPolygonFilter, this);
     },
 
     deactivated: function() {
       this.clearSubViews();
+      this._removeButtons();
       this.view_model.set('state', 'idle');
+      cdb.god.unbind('add:polygon_filter', this._addPolygonFilter, this);
     },
 
     // Set visibility of the map layer
@@ -231,6 +234,33 @@
       this.model.infowindow && this.model.infowindow.set('visibility', false);
 
       this.model.save({ 'visible': !this.model.get('visible') });
+    },
+
+
+    _addPolygonFilter: function(e) {
+      if( this.dataLayer.get('type') !== 'CartoDB' ) {
+        console.log("Skipping layer because it doesn't have filters");
+        return;
+      }
+
+      var filter = this.filters.filters.where({column: 'the_geom'});
+      if (filter.length) {
+        filter = filter[0]
+      } else {
+        filter = new cdb.admin.models.FilterDiscrete({
+            table: this.table,
+            column: 'the_geom',
+            list_view: false
+          });
+        this.filters.filters.add(filter);
+      }
+
+      var m = new cdb.admin.models.CategoricalOperation({
+        operator: 'AND',
+        operation: 'INTERSECTS',
+        text: JSON.stringify(e.layer.toGeoJSON().geometry)
+      });
+      filter.operations.reset([m]);
     },
 
     // Remove this view and the map layer

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -17,9 +17,7 @@ function GrouperLayerMapView(mapViewClass) {
       this.activeLayerModel = null;
       mapViewClass.prototype.initialize.call(this);
 
-      if (!this.options.readOnly) {
-        this._addGeometricToolbar();
-      }
+      this._addGeometricToolbar();
     },
 
     _removeLayers: function() {
@@ -586,8 +584,7 @@ cdb.admin.MapTab = cdb.core.View.extend({
     this.mapView = new mapViewClass({
       el: div,
       map: this.map,
-      user: this.user,
-      readOnly: this.vis.get('type') !== 'derived'
+      user: this.user
     });
 
     this.mapView.bind('removeLayerView', function(layerView) {

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -16,6 +16,8 @@ function GrouperLayerMapView(mapViewClass) {
       this.groupLayer = null;
       this.activeLayerModel = null;
       mapViewClass.prototype.initialize.call(this);
+
+      this._addGeometricToolbar();
     },
 
     _removeLayers: function() {
@@ -89,6 +91,25 @@ function GrouperLayerMapView(mapViewClass) {
           this._setInteraction();
         }
       }
+    },
+
+    _addGeometricToolbar: function() {
+      var drawLayer = new L.FeatureGroup();
+      this.map_leaflet.addLayer(drawLayer);
+      var drawControl = new L.Control.Draw({
+        draw: {
+          polyline: false,
+          marker: false,
+        },
+        edit: {
+          featureGroup: drawLayer,
+          edit: false,
+          remove: false
+        }
+      });
+      this.map_leaflet.addControl(drawControl);
+
+      this.map_leaflet.on('draw:created', function(e) { cdb.god.trigger('add:polygon_filter', e); });
     },
 
     /**

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -17,7 +17,9 @@ function GrouperLayerMapView(mapViewClass) {
       this.activeLayerModel = null;
       mapViewClass.prototype.initialize.call(this);
 
-      this._addGeometricToolbar();
+      if (!this.options.readOnly) {
+        this._addGeometricToolbar();
+      }
     },
 
     _removeLayers: function() {
@@ -584,7 +586,8 @@ cdb.admin.MapTab = cdb.core.View.extend({
     this.mapView = new mapViewClass({
       el: div,
       map: this.map,
-      user: this.user
+      user: this.user,
+      readOnly: this.vis.get('type') !== 'derived'
     });
 
     this.mapView.bind('removeLayerView', function(layerView) {

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -99,8 +99,14 @@ function GrouperLayerMapView(mapViewClass) {
       var drawControl = new L.Control.Draw({
         draw: {
           polyline: false,
-          marker: false,
-          polygon: false
+          polygon: {
+            // Ensure the marker used for adding a vertex ends up above everything
+            // Otherwise the add vertex clicks will be silently swallowed
+            zIndexOffset: 10000,
+            metric: false,
+            allowIntersection: false
+          },
+          marker: false
         },
         edit: {
           featureGroup: drawLayer,

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -100,7 +100,6 @@ function GrouperLayerMapView(mapViewClass) {
         draw: {
           polyline: false,
           marker: false,
-          circle: false,
           polygon: false
         },
         edit: {

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -100,6 +100,8 @@ function GrouperLayerMapView(mapViewClass) {
         draw: {
           polyline: false,
           marker: false,
+          circle: false,
+          polygon: false
         },
         edit: {
           featureGroup: drawLayer,

--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters.js
@@ -237,13 +237,11 @@ cdb.admin.mod.Filters = cdb.admin.Module.extend({
 
     _bindChangeQuery: function() {
       this.filters.bind(this.changeSQLEvents, this._filtersChanged, this);
-      cdb.god.bind('add:polygon_filter', this._addPolygonFilter, this);
       this.options.dataLayer.bind('change:sql_or_toggle', this._filtersChanged, this);
     },
 
     _unbindChangeQuery: function() {
       this.filters.unbind(this.changeSQLEvents, this._filtersChanged, this);
-      cdb.god.unbind('add:polygon_filter', this._addPolygonFilter, this);
       this.options.dataLayer.unbind('change:sql_or_toggle', this._filtersChanged, this);
     },
 
@@ -425,32 +423,6 @@ cdb.admin.mod.Filters = cdb.admin.Module.extend({
       this._scrollTo(0);
       this._refreshScroll();
 
-    },
-
-    _addPolygonFilter: function(e) {
-      if( this.options.dataLayer.get('type') !== 'CartoDB' ) {
-        console.log("Skipping layer because it doesn't have filters");
-        return;
-      }
-
-      var filter = this.filters.where({column: 'the_geom'});
-      if (filter.length) {
-        filter = filter[0]
-      } else {
-        filter = new cdb.admin.models.FilterDiscrete({
-            table: this.options.table,
-            column: 'the_geom',
-            list_view: false
-          });
-        this.filters.add(filter);
-      }
-
-      var m = new cdb.admin.models.CategoricalOperation({
-        operator: 'AND',
-        operation: 'INTERSECTS',
-        text: JSON.stringify(e.layer.toGeoJSON().geometry)
-      });
-      filter.operations.reset([m]);
     },
 
     _filtersChanged: function() {

--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters.js
@@ -229,6 +229,7 @@ cdb.admin.mod.Filters = cdb.admin.Module.extend({
        'add:operations',
        'remove:operations',
        'change:operations',
+       'reset:operations',
        'change:lower',
        'change:upper',
        'change:list_view'
@@ -236,11 +237,13 @@ cdb.admin.mod.Filters = cdb.admin.Module.extend({
 
     _bindChangeQuery: function() {
       this.filters.bind(this.changeSQLEvents, this._filtersChanged, this);
+      cdb.god.bind('add:polygon_filter', this._addPolygonFilter, this);
       this.options.dataLayer.bind('change:sql_or_toggle', this._filtersChanged, this);
     },
 
     _unbindChangeQuery: function() {
       this.filters.unbind(this.changeSQLEvents, this._filtersChanged, this);
+      cdb.god.unbind('add:polygon_filter', this._addPolygonFilter, this);
       this.options.dataLayer.unbind('change:sql_or_toggle', this._filtersChanged, this);
     },
 
@@ -422,6 +425,30 @@ cdb.admin.mod.Filters = cdb.admin.Module.extend({
 
     },
 
+    _addPolygonFilter: function(e) {
+      if( this.options.dataLayer.get('type') !== 'CartoDB' ) {
+        console.log("Skipping layer because it doesn't have filters");
+        return;
+      }
+      console.log(e);
+
+      var filter = this.filters.where({column: 'the_geom'});
+      if (filter.length === 0) {
+        this.filters.add({
+          column: 'the_geom'
+        });
+        filter = this.filters.where({column: 'the_geom'});
+      }
+      filter = filter[0];
+
+      var m = new cdb.admin.models.CategoricalOperation({
+        operator: 'AND',
+        operation: 'INTERSECTS',
+        text: JSON.stringify(e.layer.toGeoJSON().geometry)
+      });
+      filter.operations.reset([m]);
+    },
+
     _filtersChanged: function() {
 
       // Serialize to layer
@@ -518,4 +545,3 @@ cdb.admin.mod.Filters = cdb.admin.Module.extend({
     }
 
 });
-

--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters.js
@@ -342,6 +342,8 @@ cdb.admin.mod.Filters = cdb.admin.Module.extend({
     _addFilters: function() {
       var self = this;
 
+      this.$('.filters').empty();
+
       if (this.filters) {
         this.filters.each(function(f) {
           self._addFilter(f);
@@ -430,16 +432,18 @@ cdb.admin.mod.Filters = cdb.admin.Module.extend({
         console.log("Skipping layer because it doesn't have filters");
         return;
       }
-      console.log(e);
 
       var filter = this.filters.where({column: 'the_geom'});
-      if (filter.length === 0) {
-        this.filters.add({
-          column: 'the_geom'
-        });
-        filter = this.filters.where({column: 'the_geom'});
+      if (filter.length) {
+        filter = filter[0]
+      } else {
+        filter = new cdb.admin.models.FilterDiscrete({
+            table: this.options.table,
+            column: 'the_geom',
+            list_view: false
+          });
+        this.filters.add(filter);
       }
-      filter = filter[0];
 
       var m = new cdb.admin.models.CategoricalOperation({
         operator: 'AND',

--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters/templates/selection.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters/templates/selection.jst.ejs
@@ -4,20 +4,24 @@
 
   <div class="title">
     <strong class="legend u-ellipsLongText">
-      <% if (status != 'loaded') { %><%- short_legend %><% } else { %><%- legend %><% } %><% if (list_view) { %>:<% } %></strong>
+      <% if (status != 'loaded') { %><%- short_legend %><% } else { %><%- legend %><% } %><% if (list_view && legend !== "the_geom") { %>:<% } %></strong>
 
-    <% if (status == 'loading') { %><div class="<%- status %>">Loading</div><% } %>
-    <% if (status == 'only') { %><div class="<%- status %>">This column has one unique value</div><% } %>
-    <% if (status == 'empty') { %><div class="<%- status %>">This column is empty</div><% } %>
-    <% if (status == "loaded") { %>
-    <ul class="controllers<% if (!list_view || reached_limit) { %> hidden<% } %>">
-      <li><a href="#" class="all">select all</a><a href="#" class="none">clear selection</a></li>
-    </ul>
+    <% if (legend !== "the_geom") { %>
+      <% if (status == 'loading') { %><div class="<%- status %>">Loading</div><% } %>
+      <% if (status == 'only') { %><div class="<%- status %>">This column has one unique value</div><% } %>
+      <% if (status == 'empty') { %><div class="<%- status %>">This column is empty</div><% } %>
+      <% if (status == "loaded") { %>
+      <ul class="controllers<% if (!list_view || reached_limit) { %> hidden<% } %>">
+        <li><a href="#" class="all">select all</a><a href="#" class="none">clear selection</a></li>
+      </ul>
+      <% } %>
     <% } %>
 
   </div>
 
 </div>
+
+<% if (legend !== "the_geom") { %>
 
 <div class="fields <%- column_type %> <%- status %> <%- list_view ? 'list' : 'text' %>">
 
@@ -53,4 +57,5 @@
 
   </div>
 </div>
+<% } %>
 <% } %>

--- a/lib/build/files/css_files.js
+++ b/lib/build/files/css_files.js
@@ -110,6 +110,7 @@ module.exports = css_files = {
     '<%= assets_dir %>/stylesheets/vendor/codemirror.css',
     '<%= assets_dir %>/stylesheets/vendor/show-hint.css',
     '<%= assets_dir %>/stylesheets/vendor/cartodb.css',
+    '<%= assets_dir %>/stylesheets/vendor/leaflet.draw.css',
     '<%= assets_dir %>/stylesheets/table/**/*.css'
   ],
 


### PR DESCRIPTION
Introduces the ability to draw a geographic boundary on the map to filter the currently selected layer by. Map entities will only be included if they intersect with the drawn boundary (That is, partial overlap will include the item). If the layer is already filtered by boundaries, drawing new boundaries will clear the previous filter and exclusively use the new shape drawn. Drawing by circle and arbitrary polygon are not included in this pull request, and will be handled in #90 and #91.

Known issues:
- [x] Leaflet.draw interface is displayed in read-only maps.
- [x] Whether all layers or only selected layer is filtered is inconsistent.
- [x] Layer filter list does not always display entry for `the_geom` when SQL includes filter logic (May be related to a pre-existing issue of the layer list not updating to display new layers).

Screenshots:
![interface](https://cloud.githubusercontent.com/assets/1032849/17033391/efb99232-4f4b-11e6-8ee2-58a487134603.png)
![storm drawing](https://cloud.githubusercontent.com/assets/1032849/17033394/f19939fe-4f4b-11e6-90a2-f75ffb6c51e2.png)
![tornado drawing](https://cloud.githubusercontent.com/assets/1032849/17033396/f2ff279a-4f4b-11e6-8714-5ef13a14555b.png)
![tornado filtered](https://cloud.githubusercontent.com/assets/1032849/17033399/f54f3bde-4f4b-11e6-83f7-11791ed5f5fe.png)
![filter list](https://cloud.githubusercontent.com/assets/1032849/16989334/d31af3a4-4e61-11e6-98c0-e72dc4241b18.png)
![filter sql](https://cloud.githubusercontent.com/assets/1032849/16989342/dac60ca6-4e61-11e6-8a5a-9f9302f54b68.png)
