### PR TITLE
Rearrange and change sidebar buttons displayed

### DIFF
--- a/app/assets/stylesheets/table/table_panel/layer-sidebar.css.scss
+++ b/app/assets/stylesheets/table/table_panel/layer-sidebar.css.scss
@@ -105,6 +105,7 @@
         font-size: 9px;
         line-height: 90px;
         border-bottom:1px solid rgba(#999999,0.25);
+        text-transform: capitalize;
         z-index:0;
         @include opacity(0.75);
 

--- a/lib/assets/javascripts/cartodb/table/layer_panel_view.js
+++ b/lib/assets/javascripts/cartodb/table/layer_panel_view.js
@@ -484,10 +484,10 @@
       self.addModule(infowindow.render(),   ['map', 'mapLite']);
 
       /* Lateral menu modules */
-      var addColumn   = self.addToolButton('add_column', ['table', 'tableLite']);
-      var addRow      = self.addToolButton('add_row', ['table', 'tableLite']);
+      var addColumn   = self.addToolButton('add_column', ['table']);
+      var addRow      = self.addToolButton('add_row', ['table']);
       var mergeTables = self.addToolButton("merge_datasets", 'table');
-      var addGeom     = self.addToolButton('add_feature', ['map', 'mapLite']);
+      var addGeom     = self.addToolButton('add_feature', ['map']);
 
       if (!this.user.featureEnabled('disabled_ui_sql')) {
         self.addModule(sql.render(), ['table', 'tableLite', 'map', 'mapLite']);

--- a/lib/assets/javascripts/cartodb/table/layer_panel_view.js
+++ b/lib/assets/javascripts/cartodb/table/layer_panel_view.js
@@ -489,6 +489,12 @@
       var mergeTables = self.addToolButton("merge_datasets", 'table');
       var addGeom     = self.addToolButton('add_feature', ['map', 'mapLite']);
 
+      if (!this.user.featureEnabled('disabled_ui_sql')) {
+        self.addModule(sql.render(), ['table', 'tableLite', 'map', 'mapLite']);
+      }
+      self.addModule(wizards.render(),      ['map', 'mapLite']);
+      self.addModule(legends.render(),      ['map', 'mapLite']);
+
       addRow.bind('click', this._addRow, this);
       addColumn.bind('click', this.trigger.bind(this, 'addColumn', this));
       mergeTables.bind('click', this._mergeTables, this);

--- a/lib/assets/javascripts/cartodb/table/layer_panel_view.js
+++ b/lib/assets/javascripts/cartodb/table/layer_panel_view.js
@@ -477,22 +477,17 @@
         self.enableModules(enabledModules);
       }).bind('tabChanged', this._onModuleTabChanged, this);
 
-      if (!this.user.featureEnabled('disabled_ui_sql')) {
-        self.addModule(sql.render(), ['table', 'tableLite', 'map', 'mapLite']);
-      }
-      self.addModule(wizards.render(),      ['map', 'mapLite']);
-      self.addModule(infowindow.render(),   ['map', 'mapLite']);
+      self.addModule(this.filters.render(), ['table', 'tableLite', 'map', 'mapLite']);
       if (!this.user.featureEnabled('disabled_ui_cartocss')) {
         self.addModule(editorPanel.render(), ['map', 'mapLite']);
       }
-      self.addModule(legends.render(),      ['map', 'mapLite']);
-      self.addModule(this.filters.render(), ['table', 'tableLite', 'map', 'mapLite']);
+      self.addModule(infowindow.render(),   ['map', 'mapLite']);
 
       /* Lateral menu modules */
+      var addColumn   = self.addToolButton('add_column', ['table', 'tableLite']);
+      var addRow      = self.addToolButton('add_row', ['table', 'tableLite']);
       var mergeTables = self.addToolButton("merge_datasets", 'table');
-      var addRow      = self.addToolButton('add_row', 'table');
-      var addColumn   = self.addToolButton('add_column', 'table');
-      var addGeom     = self.addToolButton('add_feature', 'map');
+      var addGeom     = self.addToolButton('add_feature', ['map', 'mapLite']);
 
       addRow.bind('click', this._addRow, this);
       addColumn.bind('click', this.trigger.bind(this, 'addColumn', this));

--- a/lib/assets/javascripts/cartodb/table/right_menu.js
+++ b/lib/assets/javascripts/cartodb/table/right_menu.js
@@ -24,12 +24,26 @@
 
     render: function() {
       this.$el.addClass(this.className);
-      this.$el.append(this.className);
-      this.$el.attr("href", "#" + this.className).text(this.className.replace("_mod", "").replace(/_/g," ").replace("selected", ""));
+      this.$el.attr("href", "#" + this.className).text(this._getLabel());
       this.$el.append($('<span>').addClass("error"));
       this.$el.append($('<span>').addClass("run"));
 
       return this;
+    },
+
+    _getLabel: function() {
+      switch(this.className) {
+        case "add_feature":
+          return "add point";
+        case "cartocss_mod":
+          return "design";
+        case "infowindow_mod":
+          return "tooltip";
+        case "filters_mod":
+          return "filter";
+        default:
+          return this.className.replace("_mod", "").replace(/_/g," ").replace("selected", "");
+        }
     },
 
     show: function() {
@@ -91,7 +105,7 @@
 
     addToolButton: function(type, sections) {
       var b = this._addButton(type, sections);
-      buttons = this.$('.edit');
+      buttons = this.$('.tools');
       buttons.append(b.render().$el);
       return b;
     },


### PR DESCRIPTION
- ~~Removes the SQL, Wizard, and Legends icons from map view~~
- Renames cartocss to Design and infowindow to Tooltip
- Adds "Add Point" button to map view
- Adds "Add Column" and "Add Row" button to table view

See #30 for description and #44 for wireframes.

Screenshots:
![map view icons](https://cloud.githubusercontent.com/assets/1032849/16997793/f2c9153c-4e84-11e6-9d6c-5592c30de13e.png)
![table view icons](https://cloud.githubusercontent.com/assets/1032849/16997801/f56acf56-4e84-11e6-920b-70f9262e78cd.png)
