### PR TITLE
Use crosshair cursor in image export

### DIFF
--- a/app/assets/stylesheets/table/export_image_view.css.scss
+++ b/app/assets/stylesheets/table/export_image_view.css.scss
@@ -9,6 +9,7 @@
   position: absolute;
   width: 100%;
   height: 100%;
+  cursor: crosshair;
 }
 .ExportImageView-Header {
   @include transition(all, 200ms, ease-in-out);


### PR DESCRIPTION
Show crosshair cursor anywhere on map overlay during image export.
