### PR TITLE
Only use visualization name in export filename

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.js
@@ -57,7 +57,7 @@ module.exports = BaseDialog.extend({
   },
 
   _generateImageFilename: function() {
-    var filename = (this.vis.get('name') + ' by ' + this.user.nameOrUsername() + ' ' + moment(new Date()).format('MM DD YYYY hh mm ss'));
+    var filename = this.vis.get('name');
     return filename.replace(/ /g, '_').toLowerCase();
   },
 


### PR DESCRIPTION
When exporting image, only use viz name in exported file name.
