### PR TITLE
Open sidebar when a tab icon is clicked

### DIFF
--- a/lib/assets/javascripts/cartodb/table/actions_menu.js
+++ b/lib/assets/javascripts/cartodb/table/actions_menu.js
@@ -362,6 +362,12 @@
     _showPanel: function() {
       //TODO: The toggle button disappears on panel open
       // Switch toggle arrow
+
+      if (this.panelOpen) {
+        // Panel is already open, don't open it again
+        return;
+      }
+
       this.$('.collapse').addClass('open');
       this.panelOpen = true;
 
@@ -458,6 +464,7 @@
         v.bind('show',      self.show, self);
         v.bind('destroy',   self._removeLayer, self);
         v.bind('addColumn', self._addColumn, self);
+        v.bind('toggle', self._showPanel, self);
 
         self.addTab(layer.cid, v, { after: 0 });
         v.setActiveWorkView(self.model.get('activeWorkView'));


### PR DESCRIPTION
Selecting any tab icon on the sidebar will cause the sidebar to open. Changing the active layer does not cause the sidebar to open to avoid creating a frustrating experience in the Table view and with #31.

Screenshots not included as there is no graphical change for this PR.
