### PR TITLE
Remove "Markdown supported" message for map properties

### DIFF
--- a/lib/assets/javascripts/cartodb/table/menu_modules/edit_vis_metadata/edit_vis_form.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/edit_vis_metadata/edit_vis_form.jst.ejs
@@ -7,15 +7,6 @@
   </div>
   <div class="Form-rowData Form-rowData--withLabel Form-rowData--long">
     <textarea maxlength="<%- maxLength %>" class="Form-input Form-input--long Form-textarea js-description <% if (!isMetadataEditable) { %>is-disabled<% } %>" placeholder="<% if (isMetadataEditable) { %>Type your description here...<% } else { %>Empty description<% } %>" <% if (!isMetadataEditable) { %>readonly="readonly"<% } %>><%- visDescription %></textarea>
-    <% if (isMetadataEditable) { %>
-      <label class="EditVisMetadata-markdown js-markdown" data-title="<em>_italics_</em><br/><b>*bold*</b><br/>[link](http://link.com)">
-        <span class="EditVisMetadata-markdownIcon">
-          <i class="EditVisMetadata-markdownIconText">M</i>
-          <i class="EditVisMetadata-markdownIconChar">￬</i>
-        </span>
-        Markdown supported
-      </label>
-    <% } %>
   </div>
   <div class="Form-rowInfo"></div>
 </div>


### PR DESCRIPTION
Markdown is still supported, just not labeled.
