### PR TITLE
Change Map Properties save behavior from button to click out

### DIFF
--- a/lib/assets/javascripts/cartodb/table/menu_modules/edit_vis_metadata/edit_vis_form.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/edit_vis_metadata/edit_vis_form.jst.ejs
@@ -88,14 +88,3 @@
   </div>
   <div class="Form-rowInfo"></div>
 </div>
-
-<div class="Dialog-stickyFooter">
-  <div class="Dialog-footer EditVisMetadata-formFooter">
-    <div><%/* placeholder for flex layout */%></div>
-    <% if (isMetadataEditable) { %>
-      <button type="submit" class="Button Button--main Button--inline js-submit">
-        <span>Save</span>
-      </button>
-    <% }  %>
-  </div>
-</div>

--- a/lib/assets/javascripts/cartodb/table/menu_modules/edit_vis_metadata/edit_vis_form_view.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/edit_vis_metadata/edit_vis_form_view.js
@@ -12,7 +12,7 @@ cdb.admin.MetadataForm = cdb.core.View.extend({
   },
 
   events: {
-    'blur input': '_onSubmit',
+    'blur input': '_queueSubmit',
     'blur textarea': '_onSubmit'
   },
 
@@ -130,6 +130,13 @@ cdb.admin.MetadataForm = cdb.core.View.extend({
   },
 
   // Form events
+
+  _queueSubmit: function(ev) {
+    // By adding a new event, we guarentee that this will execute after the
+    // current event resolves.
+    // See http://stackoverflow.com/a/7760544
+    window.setTimeout(this._onSubmit.bind(this), 0);
+  },
 
   _onSubmit: function (ev) {
     if (ev) {

--- a/lib/assets/javascripts/cartodb/table/menu_modules/edit_vis_metadata/edit_vis_form_view.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/edit_vis_metadata/edit_vis_form_view.js
@@ -12,7 +12,8 @@ cdb.admin.MetadataForm = cdb.core.View.extend({
   },
 
   events: {
-    'click .js-submit': '_onSubmit'
+    'blur input': '_onSubmit',
+    'blur textarea': '_onSubmit'
   },
 
   initialize: function () {

--- a/lib/assets/javascripts/cartodb/table/menu_modules/edit_vis_metadata/edit_vis_form_view.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/edit_vis_metadata/edit_vis_form_view.js
@@ -131,7 +131,7 @@ cdb.admin.MetadataForm = cdb.core.View.extend({
 
   // Form events
 
-  _queueSubmit: function(ev) {
+  _queueSubmit: function (ev) {
     // By adding a new event, we guarentee that this will execute after the
     // current event resolves.
     // See http://stackoverflow.com/a/7760544


### PR DESCRIPTION
Saves the map description and tags list on click out and removes the save button.

Note that refreshing the page while either input still has focus will not trigger a save.

Screenshot:
![removed save button](https://cloud.githubusercontent.com/assets/1032849/17107850/f4b90702-525e-11e6-9290-8da3f19c3453.png)
