### PR TITLE
Remove labels from map properties inputs

### DIFF
--- a/app/assets/stylesheets/common/form-content.css.scss
+++ b/app/assets/stylesheets/common/form-content.css.scss
@@ -136,6 +136,7 @@ $sLabel-width: 140px;
   width: 380px;
   min-height: 40px; // if there's no input on row (e.g. only radio buttons), to avoid "jumpy" behaviour on re-renders
   margin-right: $sMargin-element;
+  margin-left: $sMargin-element;
 }
 
 .Form-rowData.Form-rowData--alignLeft { @include justify-content(flex-start, start) }
@@ -145,7 +146,7 @@ $sLabel-width: 140px;
 // RowData sizes
 .Form-rowData--full { width: 100% }
 .Form-rowData--longer { width: 460px }
-.Form-rowData--long { width: 380px }
+.Form-rowData--long { width: 345px }
 .Form-rowData--med { width: 300px }
 .Form-rowData--short { width: 170px }
 .Form-rowData--shorter {

--- a/lib/assets/javascripts/cartodb/table/menu_modules/edit_vis_metadata/edit_vis_form.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/edit_vis_metadata/edit_vis_form.jst.ejs
@@ -1,10 +1,4 @@
-<div class="title">
-  <h2>Map Properties</h2>
-</div>
 <div class="Form-row">
-  <div class="Form-rowLabel">
-    <label class="Form-label">Description</label>
-  </div>
   <div class="Form-rowData Form-rowData--withLabel Form-rowData--long">
     <textarea maxlength="<%- maxLength %>" class="Form-input Form-input--long Form-textarea js-description <% if (!isMetadataEditable) { %>is-disabled<% } %>" placeholder="<% if (isMetadataEditable) { %>Type your description here...<% } else { %>Empty description<% } %>" <% if (!isMetadataEditable) { %>readonly="readonly"<% } %>><%- visDescription %></textarea>
   </div>
@@ -13,9 +7,6 @@
 
 <% if (isDataset) { %>
   <div class="Form-row">
-    <div class="Form-rowLabel">
-      <label class="Form-label">Source</label>
-    </div>
     <div class="Form-rowData Form-rowData">
       <input class="Form-input Form-input--long js-source <% if (!isMetadataEditable) { %>is-disabled<% } %>" placeholder="Enter the source of the data" value="<%- visSource %>" <% if (!isMetadataEditable) { %>readonly="readonly"<% } %>/>
     </div>
@@ -23,9 +14,6 @@
   </div>
 
   <div class="Form-row">
-    <div class="Form-rowLabel">
-      <label class="Form-label">Attributions</label>
-    </div>
     <div class="Form-rowData Form-rowData">
       <input class="Form-input Form-input--long js-attributions <% if (!isMetadataEditable) { %>is-disabled<% } %>" placeholder="Enter the attributions of the data" value="<%- visAttributions %>" <% if (!isMetadataEditable) { %>readonly="readonly"<% } %>/>
     </div>
@@ -33,9 +21,6 @@
   </div>
 
   <div class="Form-row">
-    <div class="Form-rowLabel">
-      <label class="Form-label">License</label>
-    </div>
     <div class="Form-rowData js-license">
     </div>
     <div class="Form-rowInfo"></div>
@@ -43,9 +28,6 @@
 
   <% if (isDataLibraryEnabled) { %>
     <div class="Form-row">
-      <div class="Form-rowLabel">
-        <label class="Form-label">Display name</label>
-      </div>
       <div class="Form-rowData Form-rowData">
         <input class="Form-input Form-input--long js-displayName <% if (!isMetadataEditable) { %>is-disabled<% } %>" placeholder="Enter a good display name" value="<%- visDisplayName %>" <% if (!isMetadataEditable) { %>readonly="readonly"<% } %>/>
       </div>
@@ -55,9 +37,6 @@
 <% } %>
 
 <div class="Form-row">
-  <div class="Form-rowLabel">
-    <label class="Form-label">Tags</label>
-  </div>
   <div class="Form-rowData Form-rowData--long">
     <div class="Form-tags js-tags <% if (!isMetadataEditable) { %>is-disabled<% } %>">
       <ul class="Form-tagsList js-tagsList"></ul>
@@ -67,9 +46,6 @@
 </div>
 
 <div class="Form-row">
-  <div class="Form-rowLabel">
-    <label class="Form-label">Privacy</label>
-  </div>
   <div class="Form-rowData Form-rowData--long">
     <% if (!isMetadataEditable) { %>
       <p class="PrivacyIndicator is-<%- visPrivacy %>"><%- visPrivacy %></p>

--- a/lib/assets/javascripts/cartodb/table/menu_modules/edit_vis_metadata/edit_vis_form_view.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/edit_vis_metadata/edit_vis_form_view.js
@@ -113,7 +113,7 @@ cdb.admin.MetadataForm = cdb.core.View.extend({
     var items = cdb.config.get('licenses');
     var emptyOption = [{
       id: '',
-      name: '-'
+      name: 'Select a license...'
     }];
     return _.chain(emptyOption.concat(items))
       .compact()


### PR DESCRIPTION
Removes labels from fields describing what they do. Empty fields will have default text describing what should be there, but fields with content will show the content instead.

Screenshots:
![blank fields map](https://cloud.githubusercontent.com/assets/1032849/17112768/715fe7ce-5275-11e6-8338-874387689cd8.png)
![populated fields map](https://cloud.githubusercontent.com/assets/1032849/17112793/8d8cdd4e-5275-11e6-9f01-1cb375fef1fc.png)
