### PR TITLE
Disable Export button in table view

### DIFF
--- a/lib/assets/javascripts/cartodb/old_common/header.js
+++ b/lib/assets/javascripts/cartodb/old_common/header.js
@@ -134,6 +134,10 @@ cdb.admin.Header = cdb.core.View.extend({
   _shareVisualization: function(e) {
     this.killEvent(e);
 
+    if (this.$('a.share').hasClass('disabled')) {
+      return;
+    }
+
     var view;
     if (this.model.isVisualization()) {
       cdb.god.trigger('export_image_clicked', e);
@@ -314,7 +318,7 @@ cdb.admin.Header = cdb.core.View.extend({
   },
 
   addOverlaysDropdown: function() {
-    $(".add_overlay").removeClass('disabled');
+    $(".add_overlay, a.share").removeClass('disabled');
 
     if (!this.overlaysDropdown) {
 
@@ -338,7 +342,6 @@ cdb.admin.Header = cdb.core.View.extend({
         this.exportImageView && this.exportImageView.hide();
       }, this);
 
-
       cdb.god.bind("closeDialogs", this.overlaysDropdown.hide, this.overlaysDropdown);
       cdb.god.bind("closeOverlayDropdown", this.overlaysDropdown.hide, this.overlaysDropdown);
 
@@ -348,7 +351,7 @@ cdb.admin.Header = cdb.core.View.extend({
   },
 
   clearDropdown: function() {
-    $(".add_overlay").addClass('disabled');
+    $(".add_overlay, a.share").addClass('disabled');
 
     if (this.overlaysDropdown) {
       this.overlaysDropdown.clean();
@@ -364,7 +367,7 @@ cdb.admin.Header = cdb.core.View.extend({
   },
 
   toggleOverlaysDropdown: function(tab) {
-    $(".add_overlay").toggleClass('disabled', tab === "table");
+    $(".add_overlay, a.share").toggleClass('disabled', tab === "table");
 
     if (tab !== "table") {
       this.addOverlaysDropdown();


### PR DESCRIPTION
Prevents a bug caused by clicking the "Export" button when there is no image to export.

Screenshots:
<img width="1271" alt="disabled export" src="https://cloud.githubusercontent.com/assets/1032849/17117333/ac0c5fce-5289-11e6-8f68-b00b04e3f4a6.png">
