### PR TITLE
Widen width/height inputs and add 'px' to label

### DIFF
--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -244,12 +244,14 @@ cdb.admin.MapTab = cdb.core.View.extend({
         'width': {
           type: 'simple_number_with_label',
           value: 10, min: 10, max: 1000, inc: 5,
-          label: "Width",
+          label: "Width (px)",
+          width: 30,
           disable_triggering: true
         }, 'height': {
           type: 'simple_number_with_label',
           value: 10, min: 10, max: 1000, inc: 5,
-          label: "Height",
+          width: 30,
+          label: "Height (px)",
           disable_triggering: true
         }
       }

--- a/lib/assets/javascripts/cartodb/table/overlays/export_bar_actions.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/overlays/export_bar_actions.jst.ejs
@@ -1,6 +1,6 @@
 <div class="export-options right">
     <ul class="options">
-        <li class="do_export"><a class="btn" href="#">Save</a></li>
+        <li class="do_export"><a class="btn" href="#">Export</a></li>
         <li class="button cancel"><a class="btn" href="#">Cancel</a></li>
     </ul>
 </div>


### PR DESCRIPTION
Updates export controls to better match requests from client
- Include units in inputs
- Make inputs wider so 4 digits are not cut off
- Update 'Save' button to 'Export' (as requested in doc, breaks spec)

![bbg-export-px](https://cloud.githubusercontent.com/assets/1818302/17149010/64b1ea14-5337-11e6-9c8e-49025c75e108.png)
