### PR TITLE
Export overlay should keep dimensions on switch to custom export

### DIFF
--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -1240,6 +1240,7 @@ cdb.admin.MapTab = cdb.core.View.extend({
     // recreate image exporter view for new size
     this._removeExportImageView();
 
+    this.last_export_size = this.export_size;
     this.export_size = selectedSize;
     this._exportImage();
 
@@ -1286,11 +1287,13 @@ cdb.admin.MapTab = cdb.core.View.extend({
 
     var mapWidth = this.mapView.$el.width();
     var mapHeight = this.mapView.$el.height();
+    var lastExportSize = this.last_export_size || 'small';
 
     var width, height;
     if (this.export_size === 'custom') {
-      width = customWidth ? customWidth : mapWidth;
-      height = customHeight ? customHeight : mapHeight;
+      // Use custom dimensions or default to last standard export size
+      width = customWidth ? customWidth : this.export_sizes[lastExportSize][0];
+      height = customHeight ? customHeight : this.export_sizes[lastExportSize][1];
     } else {
       width = this.export_sizes[this.export_size][0];
       height = this.export_sizes[this.export_size][1];
@@ -1309,15 +1312,7 @@ cdb.admin.MapTab = cdb.core.View.extend({
     };
 
     var w, h;
-    if (this.export_size !== 'custom') {
-      // using a preset size
-      exportOptions.horizontalMargin = 0;
-      exportOptions.verticalMargin = 0;
-      w = mapWidth - width;
-      h = mapHeight - height;
-      exportOptions.left = w > 0 ? w / 2: 0;
-      exportOptions.top = h > 0 ? h / 2 : 0;
-    } else if (customWidth && customHeight) {
+    if (customWidth && customHeight) {
       // custom sizing set from text box
       exportOptions.horizontalMargin = 0;
       exportOptions.verticalMargin = 0;
@@ -1326,11 +1321,13 @@ cdb.admin.MapTab = cdb.core.View.extend({
       exportOptions.left = left;
       exportOptions.top = top;
     } else {
-      // custom sizing, starting with defaults
-      exportOptions.horizontalMargin = 90;
-      exportOptions.verticalMargin = 130;
-      exportOptions.left = 60;
-      exportOptions.top = 60;
+      // using a preset size
+      exportOptions.horizontalMargin = 0;
+      exportOptions.verticalMargin = 0;
+      w = mapWidth - width;
+      h = mapHeight - height;
+      exportOptions.left = w > 0 ? w / 2: 0;
+      exportOptions.top = h > 0 ? h / 2 : 0;
     }
 
     this.exportImageView = new cdb.admin.ExportImageView(exportOptions);


### PR DESCRIPTION
E.g. In the screenshot below, user enters export, then selects custom. The overlay switches to custom mode but the overlay maintains the dimensions of 'small' (500x300)

![bbg-export-dimensions-1](https://cloud.githubusercontent.com/assets/1818302/17151237/f464254c-5340-11e6-898f-b74bf5b02a48.png)
![bbg-export-dimensions-2](https://cloud.githubusercontent.com/assets/1818302/17151238/f468c2fa-5340-11e6-923f-7599bf0f4fa9.png)
