### PR TITLE
Add button to copy AVMM upload ID

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_image_result_view.js
@@ -102,7 +102,20 @@ module.exports = BaseDialog.extend({
     if (!this.avmm) {
       document.getElementById('download_link').click();
       this.close();
+    } else {
+      ZeroClipboard.setMoviePath(cdb.config.get('assets_url') + "/flash/ZeroClipboard.swf");
+      this.clip = new ZeroClipboard.Client();
+      this.clip.glue(this.$('button.avmm-copy-id').get(0));
+      this.clip.setText(this.$('.avmm-id').text().trim());
+      this.clip.addEventListener('onComplete', this._onCopy.bind(this));
     }
+  },
+
+  _onCopy: function(client, text) {
+    this.$("button.avmm-copy-id span").text("Copied!");
+    setTimeout((function() {
+      this.$("button.avmm-copy-id span").text("Copy");
+    }).bind(this), 2000)
   },
 
   _initBinds: function() {

--- a/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_to_avmm_view.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/static_image/export_to_avmm_view.jst.ejs
@@ -22,9 +22,14 @@
           <div class="Form-rowLabel">
             ID:
           </div>
-          <div class="Form-rowData">
+          <div class="Form-rowData avmm-id">
             1234567890
           </div>
+          <button class="Button Button--secondary avmm-copy-id" style="position:relative">
+            <span>
+              copy
+            </span>
+          </button>
         </div>
     </div>
   </div>


### PR DESCRIPTION
This via ZeroClipboard, which places a Flash animation on top of the actual button. This causes some unfortunate interaction with the button's `:hover` response.

Screen shots:
![copy button](https://cloud.githubusercontent.com/assets/1032849/17152891/ebca18a4-5347-11e6-8c30-a48e0e89ddcc.png)
![copied](https://cloud.githubusercontent.com/assets/1032849/17152894/f0458756-5347-11e6-8138-f4a6b9c21629.png)
