### PR TITLE
Make export image overlay always draggable

### DIFF
--- a/lib/assets/javascripts/cartodb/table/export_image_view.js
+++ b/lib/assets/javascripts/cartodb/table/export_image_view.js
@@ -143,17 +143,16 @@ cdb.admin.ExportImageView = cdb.core.View.extend({
   },
 
   _setupCanvas: function() {
+    this.$(".CanvasExport").draggableOverlay({
+      drag: this._onDrag,
+      container: this.options.mapView.$el
+    });
 
     if (this.options.custom_size) {
       this.$(".CanvasExport").resizable({
         resize: this._onResize,
         containment: this.options.mapView.$el,
         handles: "n, e, s, w, ne, se, sw, nw"
-      });
-
-      this.$(".CanvasExport").draggableOverlay({
-        drag: this._onDrag,
-        container: this.options.mapView.$el
       });
     }
 


### PR DESCRIPTION
As requested by client, the overlay should be draggable
on the preset sizes, not just custom
