### PR TITLE
Fix export image view size when re-initializing export

### DIFF
--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -215,7 +215,9 @@ cdb.admin.MapTab = cdb.core.View.extend({
     'large': [800, 600]
   },
 
+  default_export_size: 'small',
   export_size: 'small',
+  last_export_size: 'small',
 
   export_form_data: [
     {
@@ -1274,6 +1276,7 @@ cdb.admin.MapTab = cdb.core.View.extend({
 
     this._addExportBar(this.layerModel.legend, this.export_form_data);
     this.exportBar.reset(); // reset the persisted toolbar options on starting a new export
+    this.export_size = this.default_export_size;  // reset the export image view on starting new export
     this._exportImage();
   },
 
@@ -1285,7 +1288,7 @@ cdb.admin.MapTab = cdb.core.View.extend({
 
     var mapWidth = this.mapView.$el.width();
     var mapHeight = this.mapView.$el.height();
-    var lastExportSize = this.last_export_size || 'small';
+    var lastExportSize = this.last_export_size || this.default_export_size;
 
     var width, height;
     if (this.export_size === 'custom') {
@@ -1334,7 +1337,7 @@ cdb.admin.MapTab = cdb.core.View.extend({
       if (this.exportBar) {
         this._removeExportBar(true);
       }
-      this.export_size = 'small'; // back to default
+      this.export_size = this.default_export_size; // back to default
       this.exportImageView.unbind("width_height_changed");
       this.exportImageView = null;
     }, this);


### PR DESCRIPTION
The export bar was properly reset to the default size,
but the export image view was not.

Parameterizes the default export size in mapview.js
