### PR TITLE
Data library count in toolbar

### DIFF
--- a/app/controllers/carto/api/visualizations_controller.rb
+++ b/app/controllers/carto/api/visualizations_controller.rb
@@ -53,11 +53,26 @@ module Carto
           total_entries: vqb.build.count
         }
         if current_user
+          # query_builder_with_filter_from_hash builds the vis list using params, these do the same
+          # queries statically to provide counts in the header regardless of which tab is shown.
           # Prefetching at counts removes duplicates
           response.merge!({
-            total_user_entries: VisualizationQueryBuilder.new.with_types(total_types).with_user_id(current_user.id).build.count,
-            total_likes: VisualizationQueryBuilder.new.with_types(total_types).with_liked_by_user_id(current_user.id).build.count,
-            total_shared: VisualizationQueryBuilder.new.with_types(total_types).with_shared_with_user_id(current_user.id).with_user_id_not(current_user.id).with_prefetch_table.build.count
+            total_user_entries: VisualizationQueryBuilder.new.with_types(total_types)
+                                                             .with_user_id(current_user.id)
+                                                             .build.count,
+            total_likes: VisualizationQueryBuilder.new.with_types(total_types)
+                                                      .with_liked_by_user_id(current_user.id)
+                                                      .build.count,
+            total_shared: VisualizationQueryBuilder.new.with_types(total_types)
+                                                       .with_shared_with_user_id(current_user.id)
+                                                       .with_user_id_not(current_user.id)
+                                                       .with_prefetch_table
+                                                       .build.count,
+            total_library: VisualizationQueryBuilder.new.with_type(Carto::Visualization::TYPE_REMOTE)
+                                                        .with_user_id(current_user.id)
+                                                        .without_synced_external_sources
+                                                        .without_imported_remote_visualizations
+                                                        .build.count
           })
         end
         render_jsonp(response)

--- a/app/queries/carto/visualization_query_builder.rb
+++ b/app/queries/carto/visualization_query_builder.rb
@@ -250,13 +250,14 @@ class Carto::VisualizationQueryBuilder
     end
 
     if @exclude_synced_external_sources
-      query = query.joins(%Q{
+      query = query.joins(%{
                             LEFT JOIN external_sources es
                               ON es.visualization_id = visualizations.id
                           })
-                   .joins(%Q{
+                   .joins(%{
                             LEFT JOIN external_data_imports edi
-                              ON  edi.external_source_id = es.id
+                              ON edi.external_source_id = es.id
+                              AND (SELECT state FROM data_imports WHERE id = edi.data_import_id) <> 'failure'
                               #{exclude_only_synchronized}
                           })
                    .where("edi.id IS NULL")

--- a/lib/assets/javascripts/cartodb/dashboard/filters_view.js
+++ b/lib/assets/javascripts/cartodb/dashboard/filters_view.js
@@ -99,6 +99,7 @@ module.exports = cdb.core.View.extend({
             totalShared: changedContentType ? 0 : this.collection.total_shared,
             totalLiked: changedContentType ? 0 : this.collection.total_likes,
             totalItems: changedContentType ? 0 : this.collection.total_user_entries,
+            totalLibrary: changedContentType ? 0 : this.collection.total_library,
             pageItems: this.collection.size(),
             router: this.router,
             currentDashboardUrl: this.router.currentDashboardUrl(),

--- a/lib/assets/javascripts/cartodb/dashboard/views/filters.jst.ejs
+++ b/lib/assets/javascripts/cartodb/dashboard/views/filters.jst.ejs
@@ -37,6 +37,9 @@
           <% if (!isMaps) { %>
             <li class="Filters-typeItem">
               <a class="Filters-typeLink js-link <%- library ? 'is-selected' : '' %>" href="<%- currentDashboardUrl.dataLibrary() %>">
+              <% if (totalLibrary) { %>
+                <strong><%- totalLibrary %></strong>
+              <% } %>
                 Data library
               </a>
             </li>

--- a/lib/assets/javascripts/cartodb/models/vis.js
+++ b/lib/assets/javascripts/cartodb/models/vis.js
@@ -571,6 +571,7 @@ cdb.admin.Visualizations = Backbone.Collection.extend({
     this.slides && this.slides.reset(response.children);
     this.total_shared = response.total_shared;
     this.total_likes = response.total_likes;
+    this.total_library = response.total_library;
     this.total_user_entries = response.total_user_entries;
     return _.map(response.visualizations, function(v) {
       v.bindMap = false;


### PR DESCRIPTION
Adds a count next to the "Data library" link in the Datasets header.

![data_library_count](https://cloud.githubusercontent.com/assets/6598836/17677125/61e2f29c-62ff-11e6-977f-b496dd19efba.png)

Also, I ran into a bug while trying it out whereby trying to link a dataset after my quota was full would fail and not show up in the user's datasets but also no longer show up in the user's data library.  @CloudNiner pointed out that there was an issue about that upstream (https://github.com/CartoDB/cartodb/issues/9418), so I cherry-picked the fix (https://github.com/CartoDB/cartodb/pull/9428) into this branch.  With the fix, a dataset that fails to link continues to show up in the data library.
