### PR TITLE
Fix read/write table rename on datasets editor view

### DIFF
--- a/lib/assets/javascripts/cartodb/old_common/header.js
+++ b/lib/assets/javascripts/cartodb/old_common/header.js
@@ -30,10 +30,6 @@ cdb.admin.Header = cdb.core.View.extend({
     },
     share_privacy: {
       ok_next:      _t('Share it now!')
-    },
-    rename: {
-      readonly:     _t('It is not possible to rename<br/>the dataset in <%- mode %> mode'),
-      owner:        _t('It is not possible to rename<br/>the dataset if you are not the owner')
     }
   },
 
@@ -376,67 +372,6 @@ cdb.admin.Header = cdb.core.View.extend({
       //$(".add_overlay .widgets_dropdown").remove();
     }
   },
-
-
-  /**
-   *  Wait function before set new visualization attributes
-   */
-  _onSetAttributes: function(d) {
-
-    var old_data = this.model.toJSON();
-    var new_data = d;
-
-    this.model.set(d, { silent: true });
-
-    // Check if there is any difference
-    if (this.model.hasChanged()) {
-      var self = this;
-
-      this.globalError.showError(this._TEXTS.saving, 'load', -1);
-
-      this.model.save({},{
-        wait: true,
-        success: function(m) {
-          // Check if attr saved is name to change url
-          if (new_data.name !== old_data.name && !self.model.isVisualization()) {
-            window.table_router.navigate(self._generateTableUrl(), {trigger: false});
-            window.table_router.addToHistory();
-          }
-
-          self.globalError.showError(self._TEXTS.saved, 'info', 3000);
-        },
-        error: function(msg, resp) {
-          var err =  resp && JSON.parse(resp.responseText).errors[0];
-          self.globalError.showError(err, 'error', 3000);
-          self.model.set(old_data, { silent: true });
-          self.setInfo();
-        }
-      });
-    }
-
-
-  },
-
-  /**
-   *  Check if visualization/table is editable
-   *  (Checking if it is visualization and/or data layer is in sql view)
-   */
-  isVisEditable: function() {
-    if (this.model.isVisualization()) {
-      return true;
-    } else {
-      var table = this.dataLayer && this.dataLayer.table;
-
-      if (!table) {
-        return false;
-      } else if (table && (table.isReadOnly() || !table.permission.isOwner(this.options.user))) {
-        return false;
-      } else {
-        return true;
-      }
-    }
-  },
-
 
   isSyncTable: function() {
     if (this.dataLayer && this.dataLayer.table) {

--- a/lib/assets/javascripts/cartodb/table/actions_menu.js
+++ b/lib/assets/javascripts/cartodb/table/actions_menu.js
@@ -917,6 +917,37 @@
       return false;
     },
 
+    _generateTableUrl: function(e) {
+      // Let's create the url ourselves //
+      var url = '';
+
+      // Check visualization type and get table or viz id
+      if (this.vis.isVisualization()) {
+        url += '/viz/' + this.vis.get('id');
+      } else {
+        var isOwner = this.vis.permission.isOwner(this.options.user);
+        var table = new cdb.admin.CartoDBTableMetadata(this.vis.get('table'));
+
+        // Qualify table urls if user is not the owner
+        if (!isOwner) {
+          var owner_username = this.vis.permission.owner.get('username');
+          url += '/tables/' + owner_username + '.' + table.getUnqualifiedName();
+        } else {
+          url += '/tables/' + table.getUnqualifiedName();
+        }
+      }
+
+      // Get scenario parameter from event or current url (table or map)
+      var current = e ? $(e.target).attr('href') : window.location.pathname;
+      if (current.search('/map') != -1) {
+        url += '/map'
+      } else {
+        url += '/table'
+      }
+
+      return url;
+    },
+
     clean: function() {
       $(window).unbind('resize', this._checkResize);
       if (this.resize) clearTimeout(this.resize);

--- a/lib/assets/javascripts/cartodb/table/actions_menu.js
+++ b/lib/assets/javascripts/cartodb/table/actions_menu.js
@@ -24,6 +24,10 @@
         tiled:  _t('Tiled layers can\'t be above animated layers.')
       },
       raster:   _t("You can't add a raster layer into a visualization"),
+      rename: {
+        readonly:     _t('It is not possible to rename<br/>the dataset in <%- mode %> mode'),
+        owner:        _t('It is not possible to rename<br/>the dataset if you are not the owner')
+      },
       error: {
         default: _t('Something went wrong, try again later')
       }
@@ -235,7 +239,10 @@
         return true;
       } else {
         var table = this.dataLayer && this.dataLayer.table;
-
+        if (!table) {
+            var layerView = this.getActivePane();
+            table = layerView && layerView.model.table;
+        }
         if (!table) {
           return false;
         } else if (table && (table.isReadOnly() || !table.permission.isOwner(this.options.user))) {
@@ -901,6 +908,13 @@
       this.each(function(tab, pane){
         pane.setActiveWorkView(workView);
       })
+    },
+
+    isSyncTable: function() {
+      if (this.dataLayer && this.dataLayer.table) {
+        return this.dataLayer.table.isSync();
+      }
+      return false;
     },
 
     clean: function() {


### PR DESCRIPTION
There were some missing methods/text keys from the move,
this puts them in place and adds an additional attempt to
pull the current table model from the TabPanel active pane
if other attempts fail. This case is valid when we viewing
a read/write table on the datasets editor view.

![bbg-table-rename-rw](https://cloud.githubusercontent.com/assets/1818302/17810590/fe3746c2-65eb-11e6-8212-7d4d47b2eb44.png)
![bbg-tables-rename-read](https://cloud.githubusercontent.com/assets/1818302/17810589/fe36aa64-65eb-11e6-8242-e44df1f06592.png)
