### PR TITLE
Titlecase synced column names in Wizard tab

### DIFF
--- a/lib/assets/javascripts/cartodb/models/carto.js
+++ b/lib/assets/javascripts/cartodb/models/carto.js
@@ -376,6 +376,10 @@ function bubble_generator(table, props, changed, callback) {
   };
 
   var prop = props['property'];
+  // If property is an array it'll be [label, column_name], so use the column name
+  if (_.isArray(prop)) {
+    prop = prop[1];
+  }
   var min = props['radius_min'];
   var max = props['radius_max'];
   var fn = carto_functionMap[props['qfunction'] || DEFAULT_QFUNCTION];
@@ -459,6 +463,10 @@ function choropleth_generator(table, props, changed, callback) {
 
   var fn = carto_functionMap[props['qfunction'] || DEFAULT_QFUNCTION];
   var prop = props['property'];
+  // If property is an array it'll be [label, column_name], so use the column name
+  if (_.isArray(prop)) {
+    prop = prop[1];
+  }
   var nquartiles = methodMap[props['method']];
   var ramp = cdb.admin.color_ramps[props['color_ramp']][nquartiles];
 

--- a/lib/assets/javascripts/cartodb/models/table.js
+++ b/lib/assets/javascripts/cartodb/models/table.js
@@ -178,6 +178,10 @@
       return this.synchronization.isSync();
     },
 
+    isExternal: function() {
+      return this.get('synchronization') && this.get('synchronization').from_external_source;
+    },
+
     getUnqualifiedName: function() {
       var name = this.get('name');
       if (!name) return null;

--- a/lib/assets/javascripts/cartodb/models/wizard.js
+++ b/lib/assets/javascripts/cartodb/models/wizard.js
@@ -73,6 +73,15 @@ cdb.admin.FormSchema = cdb.core.Model.extend({
 
   _fillColumns: function(opts) {
     var self = this;
+
+    // External tables get their names munged to make more readable labels
+    var formatName;
+    if (self.table.isExternal()) {
+      formatName = function(name) { return [Sugar.String.titleize(name), name]; };
+    } else {
+      formatName = function(name) { return name; };
+    }
+
     // lazy shallow copy
     var attrs = JSON.parse(JSON.stringify(this.attributes));
     _.each(attrs, function(field) {
@@ -85,9 +94,7 @@ cdb.admin.FormSchema = cdb.core.Model.extend({
           for(var i in types) {
             var type = types[i];
             var columns = self.table.columnNamesByType(type);
-            extra = extra.concat(
-              _.without(columns, 'cartodb_id')
-            )
+            extra = extra.concat(_.without(columns, 'cartodb_id').map(formatName));
             if (f.default_column === type) {
               var customColumns = _.without(columns, 'cartodb_id', 'created_at', 'updated_at');
               if (customColumns.length) {


### PR DESCRIPTION
Makes the droplists for column names in the wizard tab show titlecased
labels when using an external table from the data library.  Also adjusts
the corresponding sql query composition to account for that possibility.

Companion to PR #121 and PR #122. 

![wizard_column_labels](https://cloud.githubusercontent.com/assets/6598836/17942177/4dd146ee-6a04-11e6-9e99-ee4147e88c60.png)
