### PR TITLE
Add Leaflet.draw polygon filter

### DIFF
--- a/app/assets/stylesheets/map/leaflet.css.scss
+++ b/app/assets/stylesheets/map/leaflet.css.scss
@@ -245,15 +245,15 @@
 	border: 5px solid #bbb;
 	}
 
-.leaflet-draw-section {
+.leaflet-draw {
 	position: relative;
-	top: 110px;
-	left: 58px;
+	top: 250px;
+	left: 11px;
 
 	.leaflet-draw-toolbar {
-		width: 28px;
 
 		a {
+            width: 28px;
 			background-image: url('/assets/3.23.57/images/sprites/leaflet-spritesheet.svg');
 			background-size: 270px 30px;
 			background-repeat: no-repeat;

--- a/lib/assets/javascripts/cartodb/table/mapview.js
+++ b/lib/assets/javascripts/cartodb/table/mapview.js
@@ -99,8 +99,14 @@ function GrouperLayerMapView(mapViewClass) {
       var drawControl = new L.Control.Draw({
         draw: {
           polyline: false,
-          marker: false,
-          polygon: false
+          polygon: {
+            // Ensure the marker used for adding a vertex ends up above everything
+            // Otherwise the add vertex clicks will be silently swallowed
+            zIndexOffset: 10000,
+            metric: false,
+            allowIntersection: false
+          },
+          marker: false
         },
         edit: {
           featureGroup: drawLayer,

--- a/lib/build/files/css_files.js
+++ b/lib/build/files/css_files.js
@@ -110,6 +110,7 @@ module.exports = css_files = {
     '<%= assets_dir %>/stylesheets/vendor/codemirror.css',
     '<%= assets_dir %>/stylesheets/vendor/show-hint.css',
     '<%= assets_dir %>/stylesheets/vendor/cartodb.css',
+    '<%= assets_dir %>/stylesheets/vendor/leaflet.draw.css',
     '<%= assets_dir %>/stylesheets/table/**/*.css'
   ],
 


### PR DESCRIPTION
This filter was broken due to two issues.
1. The missing css caused the 'Add vertex' marker
   added by the polyline class to be unclickable, which
   breaks the logic that saves the click point in the
   onmousedown event:
   https://github.com/Leaflet/Leaflet.draw/blob/master/src/draw/handler/Draw.Polyline.js#L253
2. The default zIndexOffset wasn't high enough to place
   the draw layer on top of all others, masking the mouse
   events.

Also updates the polygon draw options to more sensible defaults.
