### PR TITLE
Import alias information on FDW powered Data Library import

### DIFF
--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -160,6 +160,8 @@ module CartoDB
           end
           data = JSON.parse(response.response_body)
           table_visualization_map_id = data['table_visualization']['map_id']
+          table.alias = data['alias']
+          table.schema_alias = data['schema_alias']
 
           # Get remote vis layer configs
           url = "#{remote_base_url}/api/v1/maps/#{table_visualization_map_id}/layers"

--- a/app/models/carto/user_table.rb
+++ b/app/models/carto/user_table.rb
@@ -91,6 +91,16 @@ module Carto
       self.table_id = service.get_table_id
     end
 
+    def schema_alias=(hash)
+      self.alias_columns = (hash || {}).to_json
+    end
+
+    def schema_alias
+      JSON.parse(alias_columns).with_indifferent_access
+    rescue JSON::ParserError, TypeError
+      {}
+    end
+
     private
 
     def fully_qualified_name

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -45,23 +45,23 @@ class Table
   RESERVED_COLUMN_NAMES = %W{ oid tableoid xmin cmin xmax cmax ctid ogc_fid }
 
   PUBLIC_ATTRIBUTES = {
-      :id                           => :id,
-      :name                         => :name,
-      :alias                        => :alias,
-      :privacy                      => :privacy_text,
-      :schema                       => :schema,
-      :schema_alias                 => :schema_alias,
-      :updated_at                   => :updated_at,
-      :rows_counted                 => :rows_estimated,
-      :table_size                   => :table_size,
-      :map_id                       => :map_id,
-      :description                  => :description,
-      :geometry_types               => :geometry_types,
-      :table_visualization          => :table_visualization,
-      :dependent_visualizations     => :serialize_dependent_visualizations,
-      :non_dependent_visualizations => :serialize_non_dependent_visualizations,
-      :synchronization              => :serialize_synchronization
-  }
+    id: :id,
+    name: :name,
+    alias: :alias,
+    schema_alias: :schema_alias,
+    privacy: :privacy_text,
+    schema: :schema,
+    updated_at: :updated_at,
+    rows_counted: :rows_estimated,
+    table_size: :table_size,
+    map_id: :map_id,
+    description: :description,
+    geometry_types: :geometry_types,
+    table_visualization: :table_visualization,
+    dependent_visualizations: :serialize_dependent_visualizations,
+    non_dependent_visualizations: :serialize_non_dependent_visualizations,
+    synchronization: :serialize_synchronization
+  }.freeze
 
   DEFAULT_THE_GEOM_TYPE = 'geometry'
 
@@ -678,10 +678,6 @@ class Table
     end
   end
 
-  def alias
-    @user_table.alias
-  end
-
   def name=(value)
     value = value.downcase if value
     return if value == @user_table[:name] || value.blank?
@@ -742,10 +738,6 @@ class Table
     options[:connection]['SELECT pg_total_relation_size(?) AS size', name].first[:size] / 2
   rescue Sequel::DatabaseError
     nil
-  end
-
-  def schema_alias
-    JSON.parse(@user_table.alias_columns)
   end
 
   def schema(options = {})
@@ -1363,6 +1355,14 @@ class Table
   end
 
   private
+
+  def alias
+    @user_table.alias
+  end
+
+  def schema_alias
+    @user_table.schema_alias
+  end
 
   def external_source_visualization
     @user_table.

--- a/app/models/table/user_table.rb
+++ b/app/models/table/user_table.rb
@@ -293,4 +293,14 @@ class UserTable < Sequel::Model
   def actual_row_count
     service.actual_row_count
   end
+
+  def schema_alias=(hash)
+    self.alias_columns = (hash || {}).to_json
+  end
+
+  def schema_alias
+    JSON.parse(alias_columns).with_indifferent_access
+  rescue JSON::ParserError, TypeError
+    {}
+  end
 end

--- a/db/migrate/20170206160007_add_aliases_to_user_tables.rb
+++ b/db/migrate/20170206160007_add_aliases_to_user_tables.rb
@@ -1,0 +1,11 @@
+Sequel.migration do
+  up do
+    add_column :user_tables, :alias, :text
+    add_column :user_tables, :alias_columns, :text
+  end
+
+  down do
+    drop_column :user_tables, :alias
+    drop_column :user_tables, :alias_columns
+  end
+end

--- a/spec/models/carto/user_table_spec.rb
+++ b/spec/models/carto/user_table_spec.rb
@@ -32,4 +32,52 @@ describe Carto::UserTable do
 
     @user_table.sync_table_id.should eq @user_table.service.get_table_id
   end
+
+  describe('#alias') do
+    before(:each) do
+      @user_table.update_attributes!(alias: nil)
+    end
+
+    after(:all) do
+      @user_table.update_attributes!(alias: nil)
+    end
+
+    it 'sets and gets' do
+      @user_table.alias = 'foo'
+      @user_table.save
+      @user_table.reload.alias.should eq 'foo'
+    end
+  end
+
+  describe('#schema_alias') do
+    let(:schema_alias) do
+      {
+        one_column: 'with alias',
+        another_column: 'with another alias'
+      }.with_indifferent_access
+    end
+
+    before(:each) do
+      @user_table.update_attributes!(schema_alias: {})
+    end
+
+    after(:all) do
+      @user_table.update_attributes!(schema_alias: {})
+    end
+
+    it 'sets and gets' do
+      @user_table.update_attributes!(schema_alias: schema_alias)
+      @user_table.reload.schema_alias.should eq schema_alias
+    end
+
+    it 'ignores format issues' do
+      @user_table.update_attributes!(schema_alias: 'not a hash')
+      @user_table.reload.schema_alias.should(eq({}))
+    end
+
+    it 'ignores nil issues' do
+      @user_table.update_attributes!(schema_alias: nil)
+      @user_table.reload.schema_alias.should(eq({}))
+    end
+  end
 end

--- a/spec/models/user_table_spec.rb
+++ b/spec/models/user_table_spec.rb
@@ -2,9 +2,12 @@
 require_relative '../spec_helper'
 
 describe UserTable do
+  before(:each) do
+    bypass_named_maps
+  end
+
   before(:all) do
     bypass_named_maps
-
     @user = create_user(email: 'admin@cartotest.com', username: 'admin', password: '123456')
 
     @user_table = ::UserTable.new
@@ -36,5 +39,60 @@ describe UserTable do
     @user_table.table_id.should be_nil
 
     @user_table.sync_table_id.should eq @user_table.service.get_table_id
+  end
+
+  describe('#alias') do
+    before(:each) do
+      @user_table.alias = nil
+      @user_table.save!
+    end
+
+    after(:all) do
+      @user_table.alias = nil
+      @user_table.save!
+    end
+
+    it 'sets and gets' do
+      @user_table.alias = 'foo'
+      @user_table.save
+      @user_table.reload.alias.should eq 'foo'
+    end
+  end
+
+  describe('#schema_alias') do
+    let(:schema_alias) do
+      {
+        one_column: 'with alias',
+        another_column: 'with another alias'
+      }.with_indifferent_access
+    end
+
+    before(:each) do
+      @user_table.schema_alias = {}
+      @user_table.save!
+    end
+
+    after(:all) do
+      @user_table.schema_alias = {}
+      @user_table.save!
+    end
+
+    it 'sets and gets' do
+      @user_table.schema_alias = schema_alias
+      @user_table.save!
+      @user_table.reload.schema_alias.should eq schema_alias
+    end
+
+    it 'ignores format issues' do
+      @user_table.schema_alias = 'not a hash'
+      @user_table.save!
+      @user_table.reload.schema_alias.should(eq({}))
+    end
+
+    it 'ignores nil issues' do
+      @user_table.schema_alias = nil
+      @user_table.save!
+      @user_table.reload.schema_alias.should(eq({}))
+    end
   end
 end


### PR DESCRIPTION
## Context

The goal is to have table name alias and column names aliases imported in the FDW Data Library import flow. To achieve this, both aliases must be exposed through the `api/v1/tables` endpoint and recovered upon metadata import.

This PR includes some backend changes to the `feature.geographic_filter` branch. It provides some getter/setters for both `alias` and `schema_alias` in both ORM (Sequel and ActiveRecord). It includes a migration to add or remove the columns from the db automatically, and some unit tests.

## Acceptance

Make sure this code is deployed both on the data library consumer machine and the providing one.

- [ ] Table name alias functionality works
- [ ] Column name alias functionality works
- [ ] Data Library imports preserve aliases
