### PR TITLE
Save Table on importer to apply aliases

### DIFF
--- a/app/connectors/importer.rb
+++ b/app/connectors/importer.rb
@@ -162,6 +162,7 @@ module CartoDB
           table_visualization_map_id = data['table_visualization']['map_id']
           table.alias = data['alias']
           table.schema_alias = data['schema_alias']
+          table.save
 
           # Get remote vis layer configs
           url = "#{remote_base_url}/api/v1/maps/#{table_visualization_map_id}/layers"

--- a/app/models/table.rb
+++ b/app/models/table.rb
@@ -1354,15 +1354,23 @@ class Table
                           table_name: name)
   end
 
-  private
+  def alias=(alias_)
+    @user_table.alias = alias_
+  end
 
   def alias
     @user_table.alias
   end
 
+  def schema_alias=(schema_alias)
+    @user_table.schema_alias = schema_alias
+  end
+
   def schema_alias
     @user_table.schema_alias
   end
+
+  private
 
   def external_source_visualization
     @user_table.


### PR DESCRIPTION
## Context

This PR fixes a bug where no proxy setters from `Table` to `::UserTable` raised an error during imports and also adds a call to `Table#save` after setting aliases since only read actions are performed and no save is realised unless set explicitly.

## Acceptance

+ [x] Test that a dataset from Common Data with aliases preserves those aliases after import.