### PR TITLE
134 remove tooltip datasets

### DIFF
--- a/lib/assets/javascripts/cartodb/dashboard/datasets/datasets_item.js
+++ b/lib/assets/javascripts/cartodb/dashboard/datasets/datasets_item.js
@@ -87,7 +87,7 @@ module.exports = cdb.core.View.extend({
     this._renderDescription();
     this._renderTags();
     this._renderLikesIndicator();
-    this._renderTooltips();
+    // this._renderTooltips();
 
     // Item selected?
     this.$el[ vis.get('selected') ? 'addClass' : 'removeClass' ]('is--selected');

--- a/lib/assets/javascripts/cartodb/dashboard/datasets/datasets_item.js
+++ b/lib/assets/javascripts/cartodb/dashboard/datasets/datasets_item.js
@@ -87,7 +87,7 @@ module.exports = cdb.core.View.extend({
     this._renderDescription();
     this._renderTags();
     this._renderLikesIndicator();
-    // this._renderTooltips();
+    this._renderTooltips();
 
     // Item selected?
     this.$el[ vis.get('selected') ? 'addClass' : 'removeClass' ]('is--selected');

--- a/lib/assets/javascripts/cartodb/dashboard/views/datasets_item.jst.ejs
+++ b/lib/assets/javascripts/cartodb/dashboard/views/datasets_item.jst.ejs
@@ -8,7 +8,7 @@
         <p title="<%- title %>" class="DatasetsList-itemTitle is-disabled u-ellipsLongText"><%- title %></p>
       <% } else { %>
         <% if ($.inArray("bbg_pro_ui", user_data.feature_flags) !== -1) { %>
-          <a href="<%- datasetUrl %>" title="<%- title %>" class="DefaultTitle-link u-ellipsLongText"><%- title %></a>
+          <a href="<%- datasetUrl %>" class="DefaultTitle-link u-ellipsLongText"><%- title %></a>
         <% } else { %>
           <%- title %>
         <% } %>

--- a/lib/assets/javascripts/cartodb/dashboard/views/maps_item.jst.ejs
+++ b/lib/assets/javascripts/cartodb/dashboard/views/maps_item.jst.ejs
@@ -8,7 +8,7 @@
     <div class="MapCard-contentBody">
       <div class="MapCard-contentBodyRow MapCard-contentBodyRow--flex">
         <h3 class="MapCard-title DefaultTitle u-ellipsLongText">
-          <a class="DefaultTitle-link" title="<%- name %>" href="<%- url %>"><%- name %></a>
+          <a class="DefaultTitle-link" href="<%- url %>"><%- name %></a>
         </h3>
         <a href="<%- url %>" class="MapCard-editButton CDB-IconFont CDB-IconFont-pencil" title="<%- name %>"></a>
         <% if (showPermissionIndicator) { %>


### PR DESCRIPTION
This closes #134 

## Remove Tooltips from data sets list and map view list

### Changes In This PR

1. Removed title from a tag in `datasets_item.jst.ejs`.
1. Removed title from a tag in `maps_item.jst.ejs`.

### Acceptance
- [x] When mouse over or hover on data set item title no tooltip should be shown
- [x] When mouse over or hover on map list item title no tooltip should be shown
- [x] When logged in as data user the map title link should still direct to map view
- [x] When logged in as regular user the map title link should still direct to map view
- [x] When logged in as regular user the data set title should not link to data set view
- [x] When logged in as data user the data set title should still link to data set view

