### PR TITLE
Only data users in edit mode can add or edit aliases

### DIFF
--- a/lib/assets/javascripts/cartodb/table/table.js
+++ b/lib/assets/javascripts/cartodb/table/table.js
@@ -560,7 +560,7 @@ $(function() {
       this.killEvent(e);
       e.preventDefault();
       cdb.god.trigger('closeColumnDropDown');
-      if (this.user.featureEnabled('aliases')) {
+      if (this.user.featureEnabled('aliases') && this.vis.get('type') === 'table') {
         var container = $(e.target).parent().parent();
         container.append(this.titleDropdown.el);
         this.titleDropdown.openAt(20, -5);

--- a/lib/assets/javascripts/cartodb/table/views/table_header_options.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/table_header_options.jst.ejs
@@ -5,7 +5,7 @@
   <li class="order"><a class="small">Order</a> <div class="order_selector"><a class="asc" href="#asc">asc</a><a class="desc" href="#des">desc</a></div></li>
   <% if (reserved_column !== true && isPublic !== true && !in_sql_view) { %>
     <li><a class="small rename_column" href="#rename">Rename</a></li>
-    <% if (user.featureEnabled('aliases')) { %>
+    <% if (user.featureEnabled('aliases') && vis.get('type') === 'table') { %>
     <li class="alias">
       <div>
         <% if (columnAlias === null && columnAliasEdit === false) { %>


### PR DESCRIPTION
This closes #142 

## Changes In This PR
1. Added a check to see if the vis is in table mode `table.js`
1. Added a check to see if the vis is in table mode `table_header_options.jst.ejs`

## Acceptance
- [ ] When in regular user mode, user should not be able to edit or add aliases
- [ ] When in data user mode, data user should only be able to add or edit aliases when the vis is of type 'table' also known as 'Edit mode' 
- [ ] When in data user mode and data user is in a map view, data user should not be able to edit or add aliases  