### PR TITLE
146 trace error table load

### DIFF
--- a/lib/assets/javascripts/cartodb/table/layer_panel_view.js
+++ b/lib/assets/javascripts/cartodb/table/layer_panel_view.js
@@ -394,11 +394,6 @@
         dataLayer: self.dataLayer
       });
 
-      // load the scroll when the panel is open
-      // cdb.god.bind("end_narrow", function() {
-      //   self.filters.loadScroll()
-      // }, this);
-
       /* Wizards */
       var activeWizards = {
         polygon:    "SimpleWizard",

--- a/lib/assets/javascripts/cartodb/table/layer_panel_view.js
+++ b/lib/assets/javascripts/cartodb/table/layer_panel_view.js
@@ -29,7 +29,6 @@
     className: "layer_panel",
     _filtersRefreshAllowed: true,
     _filtersRefreshTimer: undefined,
-    _resizeTimer: undefined,
 
     events: {
       'click .name_info a': '_goToLayer',
@@ -90,15 +89,6 @@
 
       this.$el.attr('model-id', this.model.id);
       this._setLayerType();
-
-      $(window).on('resize', function(e) {
-        clearTimeout(self._resizeTimer);
-        self._resizeTimer = setTimeout(function() {
-          if (self.filters) {
-            self.filters.loadScroll();
-          }
-        }, 250);
-      });
     },
 
     /* Layer events functions */
@@ -405,9 +395,9 @@
       });
 
       // load the scroll when the panel is open
-      cdb.god.bind("end_narrow", function() {
-        self.filters.loadScroll()
-      }, this);
+      // cdb.god.bind("end_narrow", function() {
+      //   self.filters.loadScroll()
+      // }, this);
 
       /* Wizards */
       var activeWizards = {

--- a/lib/assets/javascripts/cartodb/table/layer_panel_view.js
+++ b/lib/assets/javascripts/cartodb/table/layer_panel_view.js
@@ -870,7 +870,6 @@
     _refreshFiltersTab: function() {
       this.filters.render();
       this.filters._addFilters();
-      this.filters.loadScroll();
     }
 
   });

--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters/histogram.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters/histogram.js
@@ -662,7 +662,6 @@
     _getAxis: function(x) {
       if(this.isNumber){
           return this._calculateTicksNum(x);
-          // xAxis.ticks(5).tickFormat(d3.format(",.0f"));
       }else if(this.isDate){
           return this._calculateTicksDate(x);
       }

--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters/selection.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters/selection.js
@@ -315,7 +315,8 @@
             this._addUserSelectedFilterField(ui.item);
           }.bind(this)
         })
-        .data("autocomplete")._renderItem = function( ul, item ) {
+        .data("ui-autocomplete")._renderItem = function( ul, item ) {
+          var a = null;
           return $( "<li>" )
             .data("item.autocomplete", item)
             .append( "<a>" + item.label + " <span style=\"float:right\">" + item.value  + "</span></a>" )
@@ -655,7 +656,7 @@
       if (this.model.get('reached_limit')) {
         setTimeout(function () {
           this._setupAutoComplete();
-        }.bind(this), 250);
+        }.bind(this), 500);
       }
       if (this.toggle) {
         $(this.$el.find('.filterListandControls')).css({display: "none"});


### PR DESCRIPTION
This closes #146 

# Changes 
Removed all calls to loadScroll() in `layer_panel_view.js`
Removed commented out code from `histogram.js`
Updated JqueryUI Autocomplete with correct div in `selection.js`

# Acceptance
Should not see `loadScroll` error in console.
JqueryUi autocomplete should now show correct template that has result and count and no error  `_renderItem` should be in console