### PR TITLE
147 filter title should show count

### DIFF
--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters/histogram.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters/histogram.js
@@ -662,7 +662,6 @@
     _getAxis: function(x) {
       if(this.isNumber){
           return this._calculateTicksNum(x);
-          // xAxis.ticks(5).tickFormat(d3.format(",.0f"));
       }else if(this.isDate){
           return this._calculateTicksDate(x);
       }

--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters/templates/histogram.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters/templates/histogram.jst.ejs
@@ -3,7 +3,7 @@
 
 <div class="header">
   <div class="title">
-    <a class="toggleButton" style="float:left; margin-right:3px" href="#">'toggle'</a>
+    <a class="toggleButton" style="float:left; margin-right:3px" href="#">(toggle)</a>
     <p class='range-text'></p>
     <strong class="legend">
       <%if (alias) { %>  

--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters/templates/selection.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters/templates/selection.jst.ejs
@@ -3,7 +3,7 @@
 <div class="header <%- status %>">
   <div class="title">
     <span>
-      <a class="toggleButton" style="float:left; margin-right:3px" href="#">'toggle'</a>
+      <a class="toggleButton" style="float:left; margin-right:3px" href="#">(toggle)</a>
       <strong class="legend u-ellipsLongText">
       <% if (status != 'loaded') { %>
         <% if (alias) { %>
@@ -19,13 +19,9 @@
         <% } %>
       <% } %>
     </strong>
+    <p class='filterCount' style="display:inline"></p>
     <% if (status == 'only') { %><div class="<%- status %>">This column has one unique value</div><% } %>
     <% if (status == 'empty') { %><div class="<%- status %>">This column is empty</div><% } %>
-    <% if (status == "loaded") { %>
-    <ul class="controllers<% if (!list_view || reached_limit) { %> hidden<% } %>">
-      <li><a href="#" class="all">select all</a><a href="#" class="none">clear selection</a></li>
-    </ul>
-    <% } %>
     </span>
 
   </div>


### PR DESCRIPTION
This closes #147 

# Changes 
Updated `selection.jst.ejs` to include `<p class='filterCount' style="display:inline"></p>`  and removed `select all` and `clear selection` a href tags


Updated toggle button to `(toggle)`

# Acceptance
Selection filters should show filter count and selected count
![screenshot from 2017-03-13 12-08-07](https://cloud.githubusercontent.com/assets/11877788/23868636/c8286a56-07e5-11e7-8906-c6aab5720246.png)
Toggle should look like `(toggle)` not `'toggle'`