### PR TITLE
Hide original dataset name for non-alias users

### DIFF
--- a/lib/assets/javascripts/cartodb/table/tableview.js
+++ b/lib/assets/javascripts/cartodb/table/tableview.js
@@ -190,7 +190,8 @@
         var table_title_alias = (this.model.get('name_alias')) ? this.model.get('name_alias') : null;
         thead.prepend(cdb.templates.getTemplate('table/views/table_title')(
           {
-            'tablename': this.model.get('name'), 
+            'tablename': this.model.get('name'),
+            'alias_feature_flag': this.user.featureEnabled('aliases'),
             'titleAlias': table_title_alias
           }
         ));

--- a/lib/assets/javascripts/cartodb/table/views/table_title.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/table_title.jst.ejs
@@ -1,6 +1,11 @@
 <div>
 <% if (titleAlias) { %>
-    <h2 class="table_title"><%- titleAlias %> (<%- tablename %>)</h2>  
+    <h2 class="table_title">
+        <%- titleAlias %> 
+        <% if (alias_feature_flag) { %>
+            (<%- tablename %>)
+        <% } %>
+    </h2>  
 <% } else {%>
     <h2 class="table_title"><%- tablename %></h2>
 <% } %>


### PR DESCRIPTION
This closes #158 

# Changes
1. Added check for alias feature flag to `table_title.jst.ejs`
1. Added `alias_feature_flag` Boolean to ` tableview.js`

# Acceptance

- [ ] Data user should see original dataset name in table view in parenthesis 
- [ ] Non data set user should see aliased dataset name only in table view