### PR TITLE
161 delete dataset needs aliasname

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
@@ -65,6 +65,7 @@ module.exports = BaseDialog.extend({
     // An entity can be an User or Organization
     var affectedEntities = this._viewModel.affectedEntities();
     var affectedVisData = this._viewModel.affectedVisData();
+
     return cdb.templates.getTemplate('common/dialogs/delete_items_view_template')({
       firstItemName: this._getFirstItemName(),
       selectedCount: this._viewModel.length,
@@ -147,6 +148,7 @@ module.exports = BaseDialog.extend({
     if (!this.options.viewModel) return;
 
     var firstItem = this.options.viewModel.at(0);
+
     if (firstItem) {
       return firstItem.get('table').name_alias || firstItem.get("name");
     }

--- a/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
@@ -65,7 +65,6 @@ module.exports = BaseDialog.extend({
     // An entity can be an User or Organization
     var affectedEntities = this._viewModel.affectedEntities();
     var affectedVisData = this._viewModel.affectedVisData();
-    
     return cdb.templates.getTemplate('common/dialogs/delete_items_view_template')({
       firstItemName: this._getFirstItemName(),
       selectedCount: this._viewModel.length,

--- a/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
@@ -65,7 +65,7 @@ module.exports = BaseDialog.extend({
     // An entity can be an User or Organization
     var affectedEntities = this._viewModel.affectedEntities();
     var affectedVisData = this._viewModel.affectedVisData();
-
+    
     return cdb.templates.getTemplate('common/dialogs/delete_items_view_template')({
       firstItemName: this._getFirstItemName(),
       selectedCount: this._viewModel.length,
@@ -148,9 +148,8 @@ module.exports = BaseDialog.extend({
     if (!this.options.viewModel) return;
 
     var firstItem = this.options.viewModel.at(0);
-
     if (firstItem) {
-      return firstItem.get("name");
+      return firstItem.get('table').name_alias || firstItem.get("name");
     }
   }
 


### PR DESCRIPTION
This closes #161 

# Changes
1. Updated `delete_items_view_template.jst.ejs` data in `delete_items_view.js` to try to  use `name_alias` first and then use `name` if not found.

# Acceptance
- [x] When removing a table the alias name should appear if table has been aliased if not the original name should appear in view.