### PR TITLE
show column alias name in delete view if avialable

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/delete_column/delete_column_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/delete_column/delete_column_view.js
@@ -24,9 +24,8 @@ module.exports = BaseDialog.extend({
   },
 
   _initViews: function() {
-
     this.table = this.options.table;
-    this.column = this.options.column;
+    this.column = this.options.table.get('column_aliases')[this.options.column] || this.options.column;
 
     this._panes = new cdb.ui.common.TabPane({
       el: this.el
@@ -57,7 +56,7 @@ module.exports = BaseDialog.extend({
 
   ok: function() {
     this._panes.active('loading');
-    this.table.deleteColumn(this.column);
+    this.table.deleteColumn(this.options.column);
     this.close();
   }
 });

--- a/lib/assets/javascripts/cartodb/common/dialogs/delete_column/delete_column_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/delete_column/delete_column_view.js
@@ -24,8 +24,13 @@ module.exports = BaseDialog.extend({
   },
 
   _initViews: function() {
+    var column_alias = null;
+    if (this.options.table.get('column_aliases') && this.options.table.get('column_aliases')[this.options.column]) {
+      column_alias = this.options.table.get('column_aliases')[this.options.column];
+    }
+
     this.table = this.options.table;
-    this.column = this.options.table.get('column_aliases')[this.options.column] || this.options.column;
+    this.column = column_alias || this.options.column;
 
     this._panes = new cdb.ui.common.TabPane({
       el: this.el


### PR DESCRIPTION
This closes #163 

# Changes
1. Delete column view `template.jst.ejs` data was updated to use column alias name if available and original column name if no alias name is available.

# Acceptance
- [x] If user deletes a column the delete column view should show the alias column name if available and if not it should show the original name.
- [x] All original delete column functionality should remain in place. 