### PR TITLE
162 fix connecting dataset template

### DIFF
--- a/lib/assets/javascripts/cartodb/common/background_polling/models/upload_model.js
+++ b/lib/assets/javascripts/cartodb/common/background_polling/models/upload_model.js
@@ -19,6 +19,7 @@ module.exports = Backbone.Model.extend({
   defaults: {
     type: '',
     value: '',
+    aliasedValue: '',
     interval: 0,
     privacy: '',
     progress: 0,

--- a/lib/assets/javascripts/cartodb/common/dialogs/create/create_loading.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/create_loading.js
@@ -23,12 +23,15 @@ module.exports = cdb.core.View.extend({
 
   render: function() {
     var currentImport = this.model.get('currentImport');
+    var upl = currentImport && currentImport.upl;
+    var currentImportName = upl && (upl.get('aliasedValue') || upl.get('service_item_id') || upl.get('value'))
+
     var d = {
       createModelType: this.createModel.get('type'),
       type: this.model.get('type'),
       state: this.model.get('state'),
       currentImport: currentImport,
-      currentImportName: currentImport && ( currentImport.upl.get('service_item_id') || currentImport.upl.get('value') ),
+      currentImportName: currentImportName,
       tableIdsArray: this.model.get('tableIdsArray'),
       selectedDatasets: this.createModel.selectedDatasets,
       upgradeUrl: window.upgrade_url,

--- a/lib/assets/javascripts/cartodb/common/dialogs/create/create_map_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/create_map_model.js
@@ -252,7 +252,7 @@ module.exports = cdb.core.Model.extend({
       var d = {
         create_vis: false,
         type: 'remote',
-        value: mdl.get('name'),
+        value: mdl.get('display_name') || mdl.get('name'),
         remote_visualization_id: mdl.get('id'),
         size: mdl.get('external_source') ? mdl.get('external_source').size : undefined
       };

--- a/lib/assets/javascripts/cartodb/common/dialogs/create/create_map_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/create/create_map_model.js
@@ -252,7 +252,8 @@ module.exports = cdb.core.Model.extend({
       var d = {
         create_vis: false,
         type: 'remote',
-        value: mdl.get('display_name') || mdl.get('name'),
+        value: mdl.get('name'),
+        aliasedValue: mdl.get('display_name'),
         remote_visualization_id: mdl.get('id'),
         size: mdl.get('external_source') ? mdl.get('external_source').size : undefined
       };


### PR DESCRIPTION
Fixes #162 

## Context

This PR modifies the `upload_model.js` to add a new `aliasedValue` attribute. It's populated from `display_name` in the `import_model.js` (which has been previously modified to show the aliased table name in remote datasets). 

Lastly, it modifies the `create_loading.js` to use this value when available.

## Acceptance

- [x] Check that the import from maps library shows an alias when available.
- [x] Check that the import from maps library shows the original name when alias is not available.
- [x] Check that normal imports with dialogs still work.

Please CR @coyle5280 