### PR TITLE
remove cartodb_id from analyze drop downs

### DIFF
--- a/lib/assets/javascripts/cartodb/models/wizard.js
+++ b/lib/assets/javascripts/cartodb/models/wizard.js
@@ -85,12 +85,11 @@ cdb.admin.FormSchema = cdb.core.Model.extend({
           for(var i in types) {
             var type = types[i];
             var columns = self.table.columnNamesByTypeAsObj(type);
-
             // Used to sort be Alias first.
+            columns = _.filter(columns, function(item) { return item[0] !== 'cartodb_id'});
             columns = _.sortBy(columns, function (r) {
                 return (r[2] || r[0]).toLowerCase();
             });
-
             extra = extra.concat(
               _.without(columns, 'cartodb_id')
             )


### PR DESCRIPTION
This closes #168 

# Changes
Used `_.filter` to remove `cartodb_id` from drop down list in file `wizard.js`.  

# Acceptance 
- [x] User should never see `cartodb_id` as a choice in any analyze drop down.  