### PR TITLE
170 analyse column sql errors

### DIFF
--- a/lib/assets/javascripts/cartodb/models/tabledata.js
+++ b/lib/assets/javascripts/cartodb/models/tabledata.js
@@ -636,7 +636,6 @@ cdb.admin.CartoDBTableData = cdb.ui.common.TableData.extend({
   },
 
   categoriesForColumn: function(max_values, column, callback, error) {
-    
     var tmpl = _.template('\
       SELECT <%= column %>, count(<%= column %>) FROM (<%= sql %>) _table_sql ' +
       'GROUP BY <%= column %> ORDER BY count DESC LIMIT <%= max_values %> '

--- a/lib/assets/javascripts/cartodb/models/tabledata.js
+++ b/lib/assets/javascripts/cartodb/models/tabledata.js
@@ -636,7 +636,7 @@ cdb.admin.CartoDBTableData = cdb.ui.common.TableData.extend({
   },
 
   categoriesForColumn: function(max_values, column, callback, error) {
-
+    
     var tmpl = _.template('\
       SELECT <%= column %>, count(<%= column %>) FROM (<%= sql %>) _table_sql ' +
       'GROUP BY <%= column %> ORDER BY count DESC LIMIT <%= max_values %> '
@@ -810,7 +810,7 @@ cdb.admin.CartoDBTableData = cdb.ui.common.TableData.extend({
   schemaFromData: function(originalTableSchema) {
     // build schema in format [ [field, type] , ...]
     var schema = cdb.admin.CartoDBTableMetadata.sortSchema(_(this.query_schema).map(function(v, k) {
-      return [k, v, null];
+      return [k, v, k];
     }));
 
     for (var k in this.alias_query_schema) {

--- a/lib/assets/javascripts/cartodb/table/header_dropdown.js
+++ b/lib/assets/javascripts/cartodb/table/header_dropdown.js
@@ -30,6 +30,7 @@ cdb.admin.HeaderDropdown = cdb.admin.DropdownMenu.extend({
     this.options.read_only = false;
     this.options.in_sql_view = false;
     this.options.columnAlias = null;
+    this.options.columnName = null;
     this.options.columnAliasEdit = false;
     this.options.isPublic = this.isPublic;
     this.elder('initialize');
@@ -51,6 +52,7 @@ cdb.admin.HeaderDropdown = cdb.admin.DropdownMenu.extend({
     this.table = table;
     this.column = column;
     this.options.columnAlias = alias;
+    this.options.columnName = column;
     // depending on column type (reserved, normal) some fields should not be shown
     // so render the dropdown again
     this.options.reserved_column = this.table.isReadOnly() || this.table.isReservedColumn(column);
@@ -94,7 +96,10 @@ cdb.admin.HeaderDropdown = cdb.admin.DropdownMenu.extend({
 
   saveAliasInput: function (e) {
     if (e) e.preventDefault();
-    this.trigger('renameAlias', this.column, $('#aliasInput').val());
+    var new_alias = $('#aliasInput').val();
+    if (this.column !== new_alias) {
+      this.trigger('renameAlias', this.column, new_alias);
+    }
   },
 
   orderColumnsAsc: function(e) {

--- a/lib/assets/javascripts/cartodb/table/views/table_header_options.jst.ejs
+++ b/lib/assets/javascripts/cartodb/table/views/table_header_options.jst.ejs
@@ -8,7 +8,7 @@
     <% if (user.featureEnabled('aliases') && vis.get('type') === 'table') { %>
     <li class="alias">
       <div>
-        <% if (columnAlias === null && columnAliasEdit === false) { %>
+        <% if (columnAlias === columnName && columnAliasEdit === false) { %>
         <p>Column Alias:</p>
         <a class="alias_column" href="#alias_column">+ Add</a>
         <% } else if(columnAliasEdit){%>


### PR DESCRIPTION
This closes #170 

# Changes
In `tabledata.js` the default value for the column alias was changed from `null` to the original column name.
Added column name to `table_header_options.jst.ejs` and `header_dropdown.js`.

# Acceptance
- [ ] In map mode all analyze wizard choice should work and no sql errors should be produced.
- [ ] Data user is stall able to rename column aliases.
- [ ] Data user should see column alias name as well as original column name
- [ ] Non-data users should only see alias name if available and original column name if no column alias exists.
- [ ] Non-data users should only see two values in table header. 1. Column name alias or original name and 2. column type.
- [ ] Data user should see three values in table header field.  Alias column name, original name and column type