### PR TITLE
Add column alias names to merge view

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/merge_datasets/column_merge/choose_key_columns_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/merge_datasets/column_merge/choose_key_columns_model.js
@@ -36,7 +36,8 @@ module.exports = cdb.core.Model.extend({
     this._resetSorting(this.get('rightColumns'));
 
     return new ChooseKeyColumnsView({
-      model: this
+      model: this,
+      user: this.get('user')
     });
   },
 
@@ -54,11 +55,23 @@ module.exports = cdb.core.Model.extend({
   },
 
   _onFetchedColumns: function(results) {
+    this._buildColumnsWithAlias(results);
+    
     var filteredColumns = this._filterColumns(results.schema);
     this.get('rightColumns').reset(filteredColumns);
     var selectedLeftColumn = this.selectedItemFor('leftColumns');
     if (selectedLeftColumn) {
       this.disableRightColumnsNotMatchingType(selectedLeftColumn.get('type'));
+    }
+  },
+
+  _buildColumnsWithAlias: function(results) {
+    for (var k = 0; k < results.schema.length; k++) {
+      if(results.column_aliases[results.schema[k][0]]) {
+        results.schema[k].push(results.column_aliases[results.schema[k][0]]);
+      } else {
+        results.schema[k].push(null);
+      }
     }
   },
 
@@ -106,13 +119,13 @@ module.exports = cdb.core.Model.extend({
 
   _filterColumns: function(tableSchema) {
     var excludeColumns = this.get('excludeColumns');
-
     return _.chain(tableSchema)
       .map(function(columnData) {
         return {
           // TODO: why don't we use a proper model for schema, to provide convenient method to get columns as a collection already?
           name: columnData[0],
-          type: columnData[1]
+          type: columnData[1],
+          alias: columnData[2]
         };
       })
       .reject(function(column) {

--- a/lib/assets/javascripts/cartodb/common/dialogs/merge_datasets/column_merge/choose_key_columns_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/merge_datasets/column_merge/choose_key_columns_view.js
@@ -43,6 +43,7 @@ module.exports = cdb.core.View.extend({
     this.addView(this._leftTableComboView);
 
     this._leftColumnsView = new ColumnsSelectorView({
+      user: this.options.user,
       collection: this.model.get('leftColumns'),
       excludeFilter: this._columnsExcludeFilter,
       selectorType: 'radio'
@@ -57,6 +58,7 @@ module.exports = cdb.core.View.extend({
     this.addView(this._rightTableSelectorView);
 
     this._rightColumnsView = new ColumnsSelectorView({
+      user: this.options.user,
       collection: this.model.get('rightColumns'),
       excludeFilter: this._columnsExcludeFilter,
       selectorType: 'radio',

--- a/lib/assets/javascripts/cartodb/common/dialogs/merge_datasets/column_selector.jst.ejs
+++ b/lib/assets/javascripts/cartodb/common/dialogs/merge_datasets/column_selector.jst.ejs
@@ -7,10 +7,25 @@
         </div>
       </div>
     <% } %>
-    <div>
-      <div class="DefaultTitle"><%- columnName %></div>
-      <p class="DefaultParagraph DefaultParagraph--tertiary"><%- columnType %></p>
-    </div>
+    <% if (aliasUser) { %>
+      <div>
+        <div class="DefaultTitle"><%- columnAlias %></div>
+        <div class="DefaultTitle"><%- columnName %></div>
+        <p class="DefaultParagraph DefaultParagraph--tertiary"><%- columnType %></p>
+      </div>
+    <% } else { %>
+      <% if (columnAlias) { %>
+        <div>
+          <div class="DefaultTitle"><%- columnAlias %></div>
+          <p class="DefaultParagraph DefaultParagraph--tertiary"><%- columnType %></p>
+        </div>
+      <% } else {%>
+        <div>
+          <div class="DefaultTitle"><%- columnName %></div>
+          <p class="DefaultParagraph DefaultParagraph--tertiary"><%- columnType %></p>
+        </div>
+      <% } %>
+    <% } %>
   </div>
   <div>
     <% if (selectorType === 'switch') { %>

--- a/lib/assets/javascripts/cartodb/common/dialogs/merge_datasets/column_selector_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/merge_datasets/column_selector_view.js
@@ -30,9 +30,11 @@ module.exports = cdb.core.View.extend({
   render: function() {
     this.$el.html(
       this.getTemplate('common/dialogs/merge_datasets/column_selector')({
+        aliasUser: this.options.user.featureEnabled('aliases'),
         selectorType: this.model.get('type'),
         columnName: this.column.get('name'),
-        columnType: this.column.get('type')
+        columnType: this.column.get('type'),
+        columnAlias: this.column.get('alias')
       })
     );
 


### PR DESCRIPTION
This closes #173 

# Changes
1. Added column alias name to column model used in merge tool.
1. Added user object to ChooseKeyColumnsView.
1. Added user object to ColumnsSelectorView.
1. Updated Merge view template to include column alias and alias feature flag bool

# Acceptance

- [ ] Pro user with alias feature flag will see both column names 
- [ ] Pro user without alias feature flag will only see column alias name if available if not will see original column name