### PR TITLE
175 georeferencing with aliases

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/admin_regions_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/admin_regions_model.js
@@ -81,15 +81,6 @@ module.exports = cdb.core.Model.extend({
     });
   },
 
-  _revertColumnName: function (value) {
-    var columnName = value;
-    var reverseColumnAliases = this.get('columnAliasesReverse');
-    if (reverseColumnAliases[columnName]) {
-      columnName = reverseColumnAliases[columnName];
-    }
-    return columnName;
-  },
-
   _initRows: function() {
     var rows = new Backbone.Collection([
       new RowModel({
@@ -123,11 +114,11 @@ module.exports = cdb.core.Model.extend({
   },
 
   _columnNameValue: function() {
-    return this._revertColumnName(this.get('rows').first().get('value'));
+    return _.invert(this.get('rows').first().get('value'));
   },
 
   _locationValue: function() {
-    return this._revertColumnName(this._location().get('value'));
+    return _.invert(this._location().get('value'));
   },
 
   _isLocationFreeText: function() {

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/admin_regions_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/admin_regions_model.js
@@ -114,11 +114,13 @@ module.exports = cdb.core.Model.extend({
   },
 
   _columnNameValue: function() {
-    return _.invert(this.get('rows').first().get('value'));
+    var value = this.get('rows').first().get('value');
+    return this.get('columnAliases')[value] || value;
   },
 
   _locationValue: function() {
-    return _.invert(this._location().get('value'));
+    var value = this._location().get('value');
+    return this.get('columnAliases')[value] || value;
   },
 
   _isLocationFreeText: function() {

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/admin_regions_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/admin_regions_model.js
@@ -81,6 +81,15 @@ module.exports = cdb.core.Model.extend({
     });
   },
 
+  _revertColumnName: function (value) {
+    var columnName = value;
+    var reverseColumnAliases = this.get('columnAliasesReverse');
+    if (reverseColumnAliases[columnName]) {
+      columnName = reverseColumnAliases[columnName];
+    }
+    return columnName;
+  },
+
   _initRows: function() {
     var rows = new Backbone.Collection([
       new RowModel({
@@ -114,11 +123,11 @@ module.exports = cdb.core.Model.extend({
   },
 
   _columnNameValue: function() {
-    return this.get('rows').first().get('value');
+    return this._revertColumnName(this.get('rows').first().get('value'));
   },
 
   _locationValue: function() {
-    return this._location().get('value');
+    return this._revertColumnName(this._location().get('value'));
   },
 
   _isLocationFreeText: function() {

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/city_names_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/city_names_model.js
@@ -99,15 +99,6 @@ module.exports = cdb.core.Model.extend({
     this.set('geocodeData', d);
   },
 
-  _revertColumnName: function (value) {
-    var columnName = value;
-    var reverseColumnAliases = this.get('columnAliasesReverse');
-    if (reverseColumnAliases[columnName]) {
-      columnName = reverseColumnAliases[columnName];
-    }
-    return columnName;
-  },
-
   _initRows: function() {
     var rows = new Backbone.Collection([
       new RowModel({
@@ -129,11 +120,13 @@ module.exports = cdb.core.Model.extend({
   },
 
   _columnNameValue: function() {
-    return this._revertColumnName(this.get('rows').first().get('value'));
+    var value = this.get('rows').first().get('value');
+    return this.get('columnAliases')[value] || value;
   },
 
   _regionValue: function() {
-    return this._revertColumnName(this._region().get('value'));
+    var value = this._region().get('value');
+    return this.get('columnAliases')[value] || value;
   },
 
   _isRegionFreeText: function() {
@@ -145,7 +138,8 @@ module.exports = cdb.core.Model.extend({
   },
 
   _locationValue: function() {
-    return this._revertColumnName(this._location().get('value'));
+    var value = this._location().get('value');
+    return this.get('columnAliases')[value] || value;
   },
 
   _isLocationFreeText: function() {

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/city_names_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/city_names_model.js
@@ -99,6 +99,15 @@ module.exports = cdb.core.Model.extend({
     this.set('geocodeData', d);
   },
 
+  _revertColumnName: function (value) {
+    var columnName = value;
+    var reverseColumnAliases = this.get('columnAliasesReverse');
+    if (reverseColumnAliases[columnName]) {
+      columnName = reverseColumnAliases[columnName];
+    }
+    return columnName;
+  },
+
   _initRows: function() {
     var rows = new Backbone.Collection([
       new RowModel({
@@ -120,11 +129,11 @@ module.exports = cdb.core.Model.extend({
   },
 
   _columnNameValue: function() {
-    return this.get('rows').first().get('value');
+    return this._revertColumnName(this.get('rows').first().get('value'));
   },
 
   _regionValue: function() {
-    return this._region().get('value');
+    return this._revertColumnName(this._region().get('value'));
   },
 
   _isRegionFreeText: function() {
@@ -136,7 +145,7 @@ module.exports = cdb.core.Model.extend({
   },
 
   _locationValue: function() {
-    return this._location().get('value');
+    return this._revertColumnName(this._location().get('value'));
   },
 
   _isLocationFreeText: function() {

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference_model.js
@@ -97,17 +97,7 @@ module.exports = cdb.core.Model.extend({
   },
 
   _columnName: function(rawColumn) {
-    //return rawColumn[0] ;
     return rawColumn[2] ;
-  },
-
-  _columnAliasesReverse: function(rawColumn) {
-    var columnAliases = this.get('table').get('column_aliases');
-    var reverseAliases = {};
-    for (var k in columnAliases) {
-      reverseAliases[columnAliases[k]] = k;
-    }
-    return reverseAliases;
   },
 
   _columnType: function(rawColumn) {
@@ -129,51 +119,47 @@ module.exports = cdb.core.Model.extend({
     this.set('geocodeStuff', m);
   },
 
-  _columnAliases: function () {
-    return this.get('table').get('column_aliases');
-  },
-
   _initOptions: function() {
     var geocodeStuff = this.get('geocodeStuff');
     var columnsNames = this._columnsNames();
     var columns = this._filteredColumns();
-    var columnAliasesReverse = this._columnAliasesReverse();
+    var columnAliases = this.get('table').get('column_aliases');
 
     this.set('options',
       new Backbone.Collection([
         new LonLatColumnsModel({
           geocodeStuff: geocodeStuff,
           columnsNames: columnsNames,
-          columnAliasesReverse: columnAliasesReverse,
+          columnAliases: columnAliases,
           selected: true
         }),
         new CityNamesModel({
           geocodeStuff: geocodeStuff,
           columnsNames: columnsNames,
-          columnAliasesReverse: columnAliasesReverse,
+          columnAliases: columnAliases,
           columns: columns
         }),
         new AdminRegionsModel({
           geocodeStuff: geocodeStuff,
           columnsNames: columnsNames,
-          columnAliasesReverse: columnAliasesReverse,
+          columnAliases: columnAliases,
           columns: columns
         }),
         new PostalCodesModel({
           geocodeStuff: geocodeStuff,
           columnsNames: columnsNames,
-          columnAliasesReverse: columnAliasesReverse,
+          columnAliases: columnAliases,
           columns: columns
         }),
         new IpAddressesModel({
           geocodeStuff: geocodeStuff,
           columnsNames: columnsNames,
-          columnAliasesReverse: columnAliasesReverse,
+          columnAliases: columnAliases,
           columns: columns
         }),
         new StreetAddressesModel({
           geocodeStuff: geocodeStuff,
-          columnAliasesReverse: columnAliasesReverse,
+          columnAliases: columnAliases,
           columns: columns,
           isGoogleMapsUser: this._isGmeGeocoderEnabled(),
           userGeocoding: this._userGeocoding(),

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference_model.js
@@ -123,7 +123,7 @@ module.exports = cdb.core.Model.extend({
     var geocodeStuff = this.get('geocodeStuff');
     var columnsNames = this._columnsNames();
     var columns = this._filteredColumns();
-    var columnAliases = this.get('table').get('column_aliases');
+    var columnAliases = _.invert(this.get('table').get('column_aliases'));
 
     this.set('options',
       new Backbone.Collection([

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/georeference_model.js
@@ -84,7 +84,7 @@ module.exports = cdb.core.Model.extend({
   _inverColumnRawValues: function(rawColumn) {
     // The cdb.forms.CustomTextCombo expects the data to be in order of [type, name], so need to translate the raw schema
     var type = rawColumn[1];
-    var name = rawColumn[0];
+    var name = rawColumn[2];
     return [type, name];
   },
 
@@ -97,7 +97,17 @@ module.exports = cdb.core.Model.extend({
   },
 
   _columnName: function(rawColumn) {
-    return rawColumn[0];
+    //return rawColumn[0] ;
+    return rawColumn[2] ;
+  },
+
+  _columnAliasesReverse: function(rawColumn) {
+    var columnAliases = this.get('table').get('column_aliases');
+    var reverseAliases = {};
+    for (var k in columnAliases) {
+      reverseAliases[columnAliases[k]] = k;
+    }
+    return reverseAliases;
   },
 
   _columnType: function(rawColumn) {
@@ -119,40 +129,51 @@ module.exports = cdb.core.Model.extend({
     this.set('geocodeStuff', m);
   },
 
+  _columnAliases: function () {
+    return this.get('table').get('column_aliases');
+  },
+
   _initOptions: function() {
     var geocodeStuff = this.get('geocodeStuff');
     var columnsNames = this._columnsNames();
     var columns = this._filteredColumns();
+    var columnAliasesReverse = this._columnAliasesReverse();
 
     this.set('options',
       new Backbone.Collection([
         new LonLatColumnsModel({
           geocodeStuff: geocodeStuff,
           columnsNames: columnsNames,
+          columnAliasesReverse: columnAliasesReverse,
           selected: true
         }),
         new CityNamesModel({
           geocodeStuff: geocodeStuff,
           columnsNames: columnsNames,
+          columnAliasesReverse: columnAliasesReverse,
           columns: columns
         }),
         new AdminRegionsModel({
           geocodeStuff: geocodeStuff,
           columnsNames: columnsNames,
+          columnAliasesReverse: columnAliasesReverse,
           columns: columns
         }),
         new PostalCodesModel({
           geocodeStuff: geocodeStuff,
           columnsNames: columnsNames,
+          columnAliasesReverse: columnAliasesReverse,
           columns: columns
         }),
         new IpAddressesModel({
           geocodeStuff: geocodeStuff,
           columnsNames: columnsNames,
+          columnAliasesReverse: columnAliasesReverse,
           columns: columns
         }),
         new StreetAddressesModel({
           geocodeStuff: geocodeStuff,
+          columnAliasesReverse: columnAliasesReverse,
           columns: columns,
           isGoogleMapsUser: this._isGmeGeocoderEnabled(),
           userGeocoding: this._userGeocoding(),

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/ip_addresses_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/ip_addresses_model.js
@@ -53,15 +53,6 @@ module.exports = cdb.core.Model.extend({
     this.set('geocodeData', d);
   },
 
-  _revertColumnName: function (value) {
-    var columnName = value;
-    var reverseColumnAliases = this.get('columnAliasesReverse');
-    if (reverseColumnAliases[columnName]) {
-      columnName = reverseColumnAliases[columnName];
-    }
-    return columnName;
-  },
-
   _initRows: function() {
     var rows = new Backbone.Collection([
       new RowModel({
@@ -75,7 +66,8 @@ module.exports = cdb.core.Model.extend({
   },
 
   _columnNameValue: function() {
-    return this._revertColumnName(this.get('rows').first().get('value'));
+    var value = this.get('rows').first().get('value');
+    return this.get('columnAliases')[value] || value;
   }
 
 });

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/ip_addresses_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/ip_addresses_model.js
@@ -53,6 +53,15 @@ module.exports = cdb.core.Model.extend({
     this.set('geocodeData', d);
   },
 
+  _revertColumnName: function (value) {
+    var columnName = value;
+    var reverseColumnAliases = this.get('columnAliasesReverse');
+    if (reverseColumnAliases[columnName]) {
+      columnName = reverseColumnAliases[columnName];
+    }
+    return columnName;
+  },
+
   _initRows: function() {
     var rows = new Backbone.Collection([
       new RowModel({
@@ -66,7 +75,7 @@ module.exports = cdb.core.Model.extend({
   },
 
   _columnNameValue: function() {
-    return this.get('rows').first().get('value');
+    return this._revertColumnName(this.get('rows').first().get('value'));
   }
 
 });

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/lon_lat_columns_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/lon_lat_columns_model.js
@@ -49,20 +49,15 @@ module.exports = cdb.core.Model.extend({
     this.set('canContinue', canContinue);
   },
 
-  _revertColumnName: function (value) {
-    var columnName = value;
-    var reverseColumnAliases = this.get('columnAliasesReverse');
-    if (reverseColumnAliases[columnName]) {
-      columnName = reverseColumnAliases[columnName];
-    }
-    return columnName;
-  },
-
   continue: function() {
+    var firstValue = this.get('rows').first().get('value');
+    var lastValue = this.get('rows').last().get('value');
+    var columnAliases = this.get('columnAliases');
+
     var d = this.get('geocodeStuff').geocodingChosenData({
       type: 'lonlat',
-      longitude: this._revertColumnName(this.get('rows').first().get('value')),
-      latitude: this._revertColumnName(this.get('rows').last().get('value'))
+      longitude: columnAliases[firstValue] || firstValue,
+      latitude: columnAliases[lastValue] || lastValue
     });
 
     this.set('geocodeData', d);

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/lon_lat_columns_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/lon_lat_columns_model.js
@@ -49,11 +49,20 @@ module.exports = cdb.core.Model.extend({
     this.set('canContinue', canContinue);
   },
 
+  _revertColumnName: function (value) {
+    var columnName = value;
+    var reverseColumnAliases = this.get('columnAliasesReverse');
+    if (reverseColumnAliases[columnName]) {
+      columnName = reverseColumnAliases[columnName];
+    }
+    return columnName;
+  },
+
   continue: function() {
     var d = this.get('geocodeStuff').geocodingChosenData({
       type: 'lonlat',
-      longitude: this.get('rows').first().get('value'),
-      latitude: this.get('rows').last().get('value')
+      longitude: this._revertColumnName(this.get('rows').first().get('value')),
+      latitude: this._revertColumnName(this.get('rows').last().get('value'))
     });
 
     this.set('geocodeData', d);

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/postal_codes_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/postal_codes_model.js
@@ -24,15 +24,6 @@ module.exports = cdb.core.Model.extend({
     if (!attrs.columns) throw new Error('columns is required');
   },
 
-  _revertColumnName: function (value) {
-    var columnName = value;
-    var reverseColumnAliases = this.get('columnAliasesReverse');
-    if (reverseColumnAliases[columnName]) {
-      columnName = reverseColumnAliases[columnName];
-    }
-    return columnName;
-  },
-
   createView: function() {
     this._initRows();
     this._setStateForFirstStep();
@@ -118,11 +109,13 @@ module.exports = cdb.core.Model.extend({
   },
 
   _columnNameValue: function() {
-    return this._revertColumnName(this.get('rows').first().get('value'));
+    var value = this.get('rows').first().get('value');
+    return this.get('columnAliases')[value] || value;
   },
 
   _locationValue: function() {
-    return this._revertColumnName(this._location().get('value'));
+    var value = this._location().get('value');
+    return this.get('columnAliases')[value] || value;
   },
 
   _isLocationFreeText: function() {

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/postal_codes_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/postal_codes_model.js
@@ -24,6 +24,15 @@ module.exports = cdb.core.Model.extend({
     if (!attrs.columns) throw new Error('columns is required');
   },
 
+  _revertColumnName: function (value) {
+    var columnName = value;
+    var reverseColumnAliases = this.get('columnAliasesReverse');
+    if (reverseColumnAliases[columnName]) {
+      columnName = reverseColumnAliases[columnName];
+    }
+    return columnName;
+  },
+
   createView: function() {
     this._initRows();
     this._setStateForFirstStep();
@@ -109,11 +118,11 @@ module.exports = cdb.core.Model.extend({
   },
 
   _columnNameValue: function() {
-    return this.get('rows').first().get('value');
+    return this._revertColumnName(this.get('rows').first().get('value'));
   },
 
   _locationValue: function() {
-    return this._location().get('value');
+    return this._revertColumnName(this._location().get('value'));
   },
 
   _isLocationFreeText: function() {

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/street_addresses/street_addresses_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/street_addresses/street_addresses_model.js
@@ -52,19 +52,11 @@ module.exports = cdb.core.Model.extend({
   },
 
   getFormatterItemByRow: function(m) {
-    var val = this._revertColumnName(m.get('value'));
+    var value = m.get('value');
+    var val = this.get('columnAliases')[value] || value;
     if (val) {
       return m.get('isFreeText') ? val.trim() : '{' + val + '}';
     }
-  },
-
-  _revertColumnName: function (value) {
-    var columnName = value;
-    var reverseColumnAliases = this.get('columnAliasesReverse');
-    if (reverseColumnAliases[columnName]) {
-      columnName = reverseColumnAliases[columnName];
-    }
-    return columnName;
   },
 
   assertIfCanAddMoreRows: function() {

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/street_addresses/street_addresses_model.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/street_addresses/street_addresses_model.js
@@ -52,10 +52,19 @@ module.exports = cdb.core.Model.extend({
   },
 
   getFormatterItemByRow: function(m) {
-    var val = m.get('value');
+    var val = this._revertColumnName(m.get('value'));
     if (val) {
       return m.get('isFreeText') ? val.trim() : '{' + val + '}';
     }
+  },
+
+  _revertColumnName: function (value) {
+    var columnName = value;
+    var reverseColumnAliases = this.get('columnAliasesReverse');
+    if (reverseColumnAliases[columnName]) {
+      columnName = reverseColumnAliases[columnName];
+    }
+    return columnName;
   },
 
   assertIfCanAddMoreRows: function() {

--- a/lib/assets/javascripts/cartodb/common/dialogs/georeference/street_addresses/street_addresses_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/georeference/street_addresses/street_addresses_view.js
@@ -141,10 +141,9 @@ module.exports = cdb.core.View.extend({
 
   _onChangeRows: function() {
     var formatter = this.model.get('rows').chain()
-      .map(this.model.getFormatterItemByRow)
+      .map(this.model.getFormatterItemByRow.bind(this.model))
       .compact() // there might be rows that have no value, if so skip them
       .value().join(', ');
-
     this.model.set({
       formatter: formatter,
       canContinue: !_.isEmpty(formatter)


### PR DESCRIPTION
This closes #175 

## Context
Updated `georeference_model.js` to build and add an object that contains the column alias names as keys and the original column name as values.  This object is included in all georef models.  Column name list is now constructed using alias column name.  Added function `_revertColumnName` to models to convert column names from alias to original if needed.

## Acceptance
- [ ] Column alias names should appear in all georef select fields.
- [ ] Original column name is sent to server for georef.
- [ ] Georef is still functional.