### PR TITLE
Adjust hist width and padding

### DIFF
--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters/histogram.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters/histogram.js
@@ -734,8 +734,8 @@
         if (g.empty()) {
 
           g = div.append("svg")
-          .attr("style", "padding:3px")
-          .attr("width", width + margin.left + margin.right)
+          .attr("style", "padding:5px")
+          .attr("width", width + margin.left + margin.right + 25)
           .attr("height", height + margin.top + margin.bottom + 25)
           .append("g")
           .attr("transform", "translate(" + margin.left + "," + margin.top + ")");


### PR DESCRIPTION
This closes #187 

# Context
This PR modifies `histogram.js`.  Additional padding and width added to histogram.  May need further adjustment when label rounding and display is adjusted.

# Acceptance
- [x] User adds a histogram filter and x axis labels are clearly visible and not cut off by edge. 