### PR TITLE
add overflow-x: hidden property

### DIFF
--- a/app/assets/stylesheets/table/table_panel/layer-views-panels/filters_panel.css.scss
+++ b/app/assets/stylesheets/table/table_panel/layer-views-panels/filters_panel.css.scss
@@ -21,6 +21,7 @@
 
   div.filters_panel {
     width:100%;
+    overflow-x: hidden;
     @include box-sizing(border-box);
 
     h3 { padding-left:30px; }


### PR DESCRIPTION
This closes #185 

# Context

The PR modifies `filters_panel.css.scss`.  `overflow-x: hidden` was added to the `div.filter_panel`.  This forces the x axis div to be hidden and allow the y-axis to scroll.  

# Acceptance
- [x] User adds a filter and no x-axis scroll is visible.
- [x] User adds filters and filter area has a y-axis scroll bar. 