### PR TITLE
hide sort if no items added to list

### DIFF
--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters/selection.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters/selection.js
@@ -715,7 +715,6 @@
             this.$el.find(".sort-a-z").hide();
             this.$el.find(".sort-default").hide();
           }
-          
         }
     },
 

--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters/selection.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters/selection.js
@@ -677,10 +677,17 @@
     _updateSortDisplay: function() {
       if(!this.userSelectedSort){
           if(this.model.get('reached_limit')){
-            this.sortFilterSelection = "Default";
-            this.$el.find(".sort-high-low").hide();
-            this.$el.find(".sort-a-z").hide();
-            this.$el.find(".sort-default").show();
+            if (this.model.items.length > 0) {
+              this.sortFilterSelection = "Default";
+              this.$el.find(".sort-high-low").hide();
+              this.$el.find(".sort-a-z").hide();
+              this.$el.find(".sort-default").show();
+            } else {
+              this.sortFilterSelection = "Default";
+              this.$el.find(".sort-high-low").hide();
+              this.$el.find(".sort-a-z").hide();
+              this.$el.find(".sort-default").hide();
+            }
           }else{
             this.sortFilterSelection = "HighLowAZ";
             this.$el.find(".sort-high-low").show();
@@ -688,19 +695,27 @@
             this.$el.find(".sort-default").hide();
           }
         }else{
-          if(this.sortFilterSelection === "Default"){
+          if (this.model.items.length > 0) {
+            if(this.sortFilterSelection === "Default"){
+              this.$el.find(".sort-high-low").hide();
+              this.$el.find(".sort-a-z").hide();
+              this.$el.find(".sort-default").show();
+            }else if(this.sortFilterSelection === "HighLowAZ"){
+              this.$el.find(".sort-high-low").show();
+              this.$el.find(".sort-a-z").hide();
+              this.$el.find(".sort-default").hide();
+            }else{
+              this.$el.find(".sort-high-low").hide();
+              this.$el.find(".sort-a-z").show();
+              this.$el.find(".sort-default").hide();
+            }
+          } else {
+            this.sortFilterSelection = "Default"
             this.$el.find(".sort-high-low").hide();
             this.$el.find(".sort-a-z").hide();
-            this.$el.find(".sort-default").show();
-          }else if(this.sortFilterSelection === "HighLowAZ"){
-            this.$el.find(".sort-high-low").show();
-            this.$el.find(".sort-a-z").hide();
-            this.$el.find(".sort-default").hide();
-          }else{
-            this.$el.find(".sort-high-low").hide();
-            this.$el.find(".sort-a-z").show();
             this.$el.find(".sort-default").hide();
           }
+          
         }
     },
 


### PR DESCRIPTION
This closes #188 

# Context

This PR modifies `selection.js`.  Logic was added to hide sort filter if item count is 0.

# Acceptance

- [x] User adds selection filter with options that exceed 250+ and sees no sort options.
- [x] User searches and then adds item to selection and sees sort filter. Sort will be `Default order`.
- [x] User can change sort type with no issues.
- [x] User removes all items and sort option will disappear.
- [x] Sort filter will always default to `Default order`. 