### PR TITLE
highlight search term

### DIFF
--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters/selection.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters/selection.js
@@ -318,12 +318,16 @@
           }.bind(this)
         })
         .data("ui-autocomplete")._renderItem = function( ul, item ) {
-          var value = "<a>" + item.label + " <span style=\"float:right\">" + item.value  + "</span></a>";
+          var value;
           var idx = -1;
+          
           if (typeof item.label === 'string' && typeof search_term === 'string') {
             idx = item.label.toLowerCase().indexOf(search_term.toLowerCase());
           }
-          if (idx !== -1) {
+
+          if (idx === -1) {
+            value = "<a>" + item.label + " <span style=\"float:right\">" + item.value  + "</span></a>";
+          } else {
             var tmpLabel = item.label;
             value = [
               "<a>", 

--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters/selection.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters/selection.js
@@ -293,9 +293,11 @@
     },
 
     _setupAutoComplete: function () {
+      var search_term;
       if(this.$el.find('.filterInputRemote').length > 0){
         this.$el.find('.filterInputRemote').autocomplete({
           source: function(request, response) {
+            search_term = request.term;
             var column = this.model.get('column');
             var sql = "SELECT " + column + " as label, count(*) as value From " + this.model.table.id +
               " WHERE " + column + " ILIKE '" + request.term + "%' GROUP BY " + column;
@@ -316,10 +318,26 @@
           }.bind(this)
         })
         .data("ui-autocomplete")._renderItem = function( ul, item ) {
-          var a = null;
+          var value = "<a>" + item.label + " <span style=\"float:right\">" + item.value  + "</span></a>";
+          var idx = -1;
+          if (typeof item.label === 'string' && typeof search_term === 'string') {
+            idx = item.label.toLowerCase().indexOf(search_term.toLowerCase());
+          }
+          if (idx !== -1) {
+            var tmpLabel = item.label;
+            value = [
+              "<a>", 
+              tmpLabel.slice(0, idx), 
+              '<span class="highlight" style="background-color: #ff9e24;">', 
+              tmpLabel.slice(idx, idx + search_term.length), 
+              "</span>", 
+              tmpLabel.slice(idx + search_term.length, tmpLabel.length), 
+              " <span style=\"float:right\">" + item.value  + "</span></a>"
+            ].join('');
+          }
           return $( "<li>" )
             .data("item.autocomplete", item)
-            .append( "<a>" + item.label + " <span style=\"float:right\">" + item.value  + "</span></a>" )
+            .append(value)
             .appendTo( ul );
         }
       }


### PR DESCRIPTION
This closes #189 

# Context

This PR modifies `selection.js`. `<span>` tag is inserted before and after search term in result to allow highlighting.  

# Acceptance
- [x] When user searches for an item the search term should be highlighted in Bloomberg orange in each result. 
- [x] No letters should be missing from returned results.
- [x] When a user selects an item it should be added to list.