### PR TITLE
add more padding to histogram

### DIFF
--- a/lib/assets/javascripts/cartodb/table/menu_modules/filters/histogram.js
+++ b/lib/assets/javascripts/cartodb/table/menu_modules/filters/histogram.js
@@ -734,8 +734,8 @@
         if (g.empty()) {
 
           g = div.append("svg")
-          .attr("style", "padding:3px")
-          .attr("width", width + margin.left + margin.right)
+          .attr("style", "padding:5px")
+          .attr("width", width + margin.left + margin.right + 35)
           .attr("height", height + margin.top + margin.bottom + 25)
           .append("g")
           .attr("transform", "translate(" + margin.left + "," + margin.top + ")");


### PR DESCRIPTION
This closes #187 

# Context
This PR modifies `histogram.js`.  It adds more padding to the histogram.  This is to prevent labels from being cutoff when displayed.

# Acceptance 
- [x] Histogram labels are clearly visible and not cut off

![capture](https://user-images.githubusercontent.com/11877788/31828011-54661c46-b576-11e7-9a84-874697094786.JPG)
