### PR TITLE
Updated alias name return to also show original name in parentheses

### DIFF
--- a/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
@@ -65,7 +65,6 @@ module.exports = BaseDialog.extend({
     // An entity can be an User or Organization
     var affectedEntities = this._viewModel.affectedEntities();
     var affectedVisData = this._viewModel.affectedVisData();
-
     return cdb.templates.getTemplate('common/dialogs/delete_items_view_template')({
       firstItemName: this._getFirstItemName(),
       selectedCount: this._viewModel.length,
@@ -150,7 +149,7 @@ module.exports = BaseDialog.extend({
     var firstItem = this.options.viewModel.at(0);
 
     if (firstItem) {
-      return firstItem.get('name_alias') || firstItem.get("name");
+      return (firstItem.get('name_alias')) ?  firstItem.get('name_alias') + ' (' + firstItem.get("name") + ')' : firstItem.get("name");
     }
   }
 

--- a/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
+++ b/lib/assets/javascripts/cartodb/common/dialogs/delete_items_view.js
@@ -5,6 +5,7 @@ var randomQuote = require('../view_helpers/random_quote');
 var MapCardPreview = require('../views/mapcard_preview');
 var $ = require('jquery-cdb-v3');
 var moment = require('moment');
+var presentAlias = require('../view_helpers/alias_presenter');
 
 var AFFECTED_ENTITIES_SAMPLE_COUNT = 3;
 var AFFECTED_VIS_COUNT = 3;
@@ -149,7 +150,11 @@ module.exports = BaseDialog.extend({
     var firstItem = this.options.viewModel.at(0);
 
     if (firstItem) {
-      return (firstItem.get('name_alias')) ?  firstItem.get('name_alias') + ' (' + firstItem.get("name") + ')' : firstItem.get("name");
+      return presentAlias({
+        user: this.options.user,
+        original: firstItem.get("name"),
+        alias: firstItem.get('name_alias')
+      })
     }
   }
 


### PR DESCRIPTION
This closes #197 

# Context
This PR modifies `delete_items_view.js`.  Data set alias name is shown w/ original name in parenthesis on  delete confirmation page.

# Acceptance
- [x]  Data set alias name appears on delete data set confirmation page.
- [x] Date set original name appears on delete data set confirmation page when no alias has been applied.