### PR TITLE
use default pointer on li &hover

### DIFF
--- a/app/assets/stylesheets/table/table_panel/layer-views-panels/filters_panel.css.scss
+++ b/app/assets/stylesheets/table/table_panel/layer-views-panels/filters_panel.css.scss
@@ -504,7 +504,7 @@
           margin: 0;
 
           &:hover {
-            cursor: pointer;
+            cursor: default;
           }
 
           p {


### PR DESCRIPTION
This closes #191 

# Context

This PR modifies 'filter_panel.css.scss`. Default cursor was added to .items li class.

# Acceptance
- [x] When user hovers mouse over selection list cursor does no change and remains as default. 