### PR TITLE
Increases organization quota for VisualizationExportService2 spec

### DIFF
--- a/spec/factories/organizations_contexts.rb
+++ b/spec/factories/organizations_contexts.rb
@@ -30,7 +30,7 @@ shared_context 'organization with users helper' do
   def test_organization
     organization = Organization.new
     organization.name = unique_name('org')
-    organization.quota_in_bytes = 1234567890
+    organization.quota_in_bytes = 3145728000
     organization.seats = 15
     organization.viewer_seats = 15
     organization.builder_enabled = false

--- a/spec/services/carto/visualizations_export_service_2_spec.rb
+++ b/spec/services/carto/visualizations_export_service_2_spec.rb
@@ -829,6 +829,10 @@ describe Carto::VisualizationsExportService2 do
       include CartoDB::Factories
 
       before(:all) do
+        # Need to up the quota because we need to have enough room for 6 different users
+        @organization.quota_in_bytes = 3145728000 # 262144000 * 12
+        @organization.save
+
         @helper = TestUserFactory.new
         @org_user_with_dash_1 = @helper.create_test_user(unique_name('user-1-'), @organization)
         @org_user_with_dash_2 = @helper.create_test_user(unique_name('user-2-'), @organization)

--- a/spec/services/carto/visualizations_export_service_2_spec.rb
+++ b/spec/services/carto/visualizations_export_service_2_spec.rb
@@ -829,10 +829,6 @@ describe Carto::VisualizationsExportService2 do
       include CartoDB::Factories
 
       before(:all) do
-        # Need to up the quota because we need to have enough room for 6 different users
-        @organization.quota_in_bytes = 3145728000 # 262144000 * 12
-        @organization.save
-
         @helper = TestUserFactory.new
         @org_user_with_dash_1 = @helper.create_test_user(unique_name('user-1-'), @organization)
         @org_user_with_dash_2 = @helper.create_test_user(unique_name('user-2-'), @organization)


### PR DESCRIPTION
The VisualizationsExportService2 tests appear to create 6 different users in the pre-test setups.  However the default organization quota of 1234567890 only has enough space for ~4 users with the default quota of 2621440000 per user leader to user creation errors.