### PR TITLE
Rdsimaps3142 unit test fix importer2 content guesser

### DIFF
--- a/services/importer/lib/importer/content_guesser.rb
+++ b/services/importer/lib/importer/content_guesser.rb
@@ -124,12 +124,12 @@ module CartoDB
         if normalizer
           sample.each do |row|
             elem = normalizer.call(row[column_name_sym])
-            frequency_table[elem] += 1 rescue frequency_table[elem] = 1
+            (frequency_table[elem] += 1) rescue frequency_table[elem] = 1
           end
         else
           sample.each do |row|
             elem = row[column_name_sym]
-            frequency_table[elem] += 1 rescue frequency_table[elem] = 1
+            (frequency_table[elem] += 1) rescue frequency_table[elem] = 1
           end
         end
         length = sample.count.to_f

--- a/spec/services/carto/visualizations_export_service_2_spec.rb
+++ b/spec/services/carto/visualizations_export_service_2_spec.rb
@@ -829,6 +829,10 @@ describe Carto::VisualizationsExportService2 do
       include CartoDB::Factories
 
       before(:all) do
+        # Need to up the quota because we need to have enough room for 6 different users
+        @organization.quota_in_bytes = 3145728000 # 262144000 * 12
+        @organization.save
+
         @helper = TestUserFactory.new
         @org_user_with_dash_1 = @helper.create_test_user(unique_name('user-1-'), @organization)
         @org_user_with_dash_2 = @helper.create_test_user(unique_name('user-2-'), @organization)

--- a/spec/services/carto/visualizations_export_service_2_spec.rb
+++ b/spec/services/carto/visualizations_export_service_2_spec.rb
@@ -829,10 +829,6 @@ describe Carto::VisualizationsExportService2 do
       include CartoDB::Factories
 
       before(:all) do
-        # Need to up the quota because we need to have enough room for 6 different users
-        @organization.quota_in_bytes = 3145728000 # 262144000 * 12
-        @organization.save
-
         @helper = TestUserFactory.new
         @org_user_with_dash_1 = @helper.create_test_user(unique_name('user-1-'), @organization)
         @org_user_with_dash_2 = @helper.create_test_user(unique_name('user-2-'), @organization)


### PR DESCRIPTION
The inline rescue was not capturing the NoMethodError from utilizing '+' on a nil class.  This may be related to https://bugs.ruby-lang.org/issues/13005.  