### PR TITLE
Adds "Copy" suffix to name of exported maps

### DIFF
--- a/app/controllers/carto/api/visualization_exports_controller.rb
+++ b/app/controllers/carto/api/visualization_exports_controller.rb
@@ -45,7 +45,9 @@ module Carto
         # In order to generate paths you need to be in a controller, so path is sent to Resque
         download_path_params = { visualization_export_id: visualization_export.id }
         download_path = CartoDB.path(self, 'visualization_export_download', download_path_params)
-        Resque.enqueue(Resque::ExporterJobs, job_id: visualization_export.id, download_path: download_path)
+        # Hack - Samples 2.0 Save As
+        # name_suffix is hardcoded.
+        Resque.enqueue(Resque::ExporterJobs, job_id: visualization_export.id, download_path: download_path, name_suffix: "Copy")
 
         if current_viewer
           current_viewer_id = current_viewer.id

--- a/app/models/carto/visualization_export.rb
+++ b/app/models/carto/visualization_export.rb
@@ -43,12 +43,12 @@ module Carto
        rv[0, pos]
     end
 
-    def run_export!(file_upload_helper: default_file_upload_helper, download_path: nil)
+    def run_export!(file_upload_helper: default_file_upload_helper, download_path: nil, name_suffix: nil)
       logger = Carto::Log.new(type: 'visualization_export')
 
       logger.append('Exporting')
       update_attributes(state: STATE_EXPORTING, log: logger)
-      filepath = export(visualization, user, user_tables_ids: user_tables_ids)
+      filepath = export(visualization, user, user_tables_ids: user_tables_ids, name_suffix: name_suffix)
 
       logger.append('Uploading')
       update_attributes(state: STATE_UPLOADING, file: filepath)

--- a/app/services/carto/visualizations_export_service_2.rb
+++ b/app/services/carto/visualizations_export_service_2.rb
@@ -207,6 +207,14 @@ module Carto
       export_visualization_json_hash(visualization_id, user).to_json
     end
 
+    def export_visualization_json_string_with_name_suffix(visualization_id, user, name_suffix)
+      # Sample 2.0 Save As Hack
+      # There should be a separate save as resque job instead which will perform this change
+      vis = export_visualization_json_hash(visualization_id, user)
+      vis[:visualization][:name] = vis[:visualization][:name] + " " + name_suffix
+      vis.to_json
+    end
+
     def export_visualization_json_hash(visualization_id, user)
       {
         version: CURRENT_VERSION,

--- a/lib/carto/visualization_exporter.rb
+++ b/lib/carto/visualization_exporter.rb
@@ -135,7 +135,8 @@ module Carto
                format: DEFAULT_EXPORT_FORMAT,
                data_exporter: DataExporter.new,
                visualization_export_service: Carto::VisualizationsExportService2.new,
-               base_dir: exporter_folder)
+               base_dir: exporter_folder,
+               name_suffix: nil)
       visualization_id = visualization.id
       export_dir = export_dir(visualization, base_dir: base_dir)
       tmp_dir = tmp_dir(visualization, parent_dir: export_dir)
@@ -148,7 +149,11 @@ module Carto
         format,
         user_tables_ids: user_tables_ids)
 
-      visualization_json = visualization_export_service.export_visualization_json_string(visualization_id, user)
+      if name_suffix
+        visualization_json = visualization_export_service.export_visualization_json_string_with_name_suffix(visualization_id, user, name_suffix)
+      else
+        visualization_json = visualization_export_service.export_visualization_json_string(visualization_id, user)
+      end
       visualization_json_file = "#{tmp_dir}/#{visualization_id}#{EXPORT_EXTENSION}"
       File.open(visualization_json_file, 'w') { |file| file.write(visualization_json) }
 

--- a/lib/resque/exporter_jobs.rb
+++ b/lib/resque/exporter_jobs.rb
@@ -8,7 +8,8 @@ module Resque
     def self.perform(options = {})
       run_action(options, @queue, lambda do |options|
         download_path = options['download_path']
-        Carto::VisualizationExport.find(options.symbolize_keys[:job_id]).run_export!(download_path: download_path)
+        name_suffix = options['name_suffix']
+        Carto::VisualizationExport.find(options.symbolize_keys[:job_id]).run_export!(download_path: download_path, name_suffix: name_suffix)
       end)
     end
   end

--- a/spec/services/carto/visualizations_export_service_2_spec.rb
+++ b/spec/services/carto/visualizations_export_service_2_spec.rb
@@ -1333,6 +1333,35 @@ describe Carto::VisualizationsExportService2 do
       destroy_visualization(imported_viz.id)
     end
 
+    it 'importing an exported visualization should create a new visualization with matching metadata and suffix name' do
+      exported_string = export_service.export_visualization_json_string_with_name_suffix(@visualization.id, @user, "Copy")
+      built_viz = export_service.build_visualization_from_json_export(exported_string)
+      imported_viz = Carto::VisualizationsExportPersistenceService.new.save_import(@user, built_viz)
+
+      imported_viz = Carto::Visualization.find(imported_viz.id)
+      verify_visualizations_match(imported_viz,
+                                  @visualization,
+                                  importing_user: @user,
+                                  imported_name: "#{@visualization.name} Copy")
+
+      destroy_visualization(imported_viz.id)
+    end
+
+    it 'importing an exported visualization several times should change imported name with suffix name' do
+      exported_string = export_service.export_visualization_json_string_with_name_suffix(@visualization.id, @user, "Copy")
+
+      built_viz = export_service.build_visualization_from_json_export(exported_string)
+      imported_viz = Carto::VisualizationsExportPersistenceService.new.save_import(@user, built_viz)
+      imported_viz.name.should eq "#{@visualization.name} Copy"
+
+      built_viz = export_service.build_visualization_from_json_export(exported_string)
+      imported_viz2 = Carto::VisualizationsExportPersistenceService.new.save_import(@user, built_viz)
+      imported_viz2.name.should eq "#{@visualization.name} Copy Import"
+
+      destroy_visualization(imported_viz.id)
+      destroy_visualization(imported_viz2.id)
+    end
+
     describe 'basemaps' do
       describe 'custom' do
         before(:each) do


### PR DESCRIPTION
Re-merging Samples 2.0 Save As "Copy" suffix logic from https://github.com/cartodb-org/cartodb/pull/226. 