### PR TITLE
Fixes permissions for shared datasets

### DIFF
--- a/app/models/carto/visualization.rb
+++ b/app/models/carto/visualization.rb
@@ -175,7 +175,7 @@ class Carto::Visualization < ActiveRecord::Base
   end
 
   def related_tables_and_common_shared_data_readable_by(user)
-    layers_with_data_readable_by(user).map { |l| l.user_tables_and_common_shared_data_readable_by(user) }.flatten.uniq
+    layers_with_data_and_common_shared_data_readable_by(user).map { |l| l.user_tables_and_common_shared_data_readable_by(user) }.flatten.uniq
   end
 
   def related_canonical_visualizations


### PR DESCRIPTION
Includes shared datasets (public datasets owned by maps data) in list of related_tables_and_common_shared_data_readable_by().  This is used for export of map as part of Samples 2.0 Save As