### PR TITLE
Changes search path of Carto::User to match ::User

### DIFF
--- a/app/models/carto/user_db_service.rb
+++ b/app/models/carto/user_db_service.rb
@@ -7,6 +7,7 @@ module Carto
     SCHEMA_CARTODB = 'cartodb'.freeze
     SCHEMA_IMPORTER = 'cdb_importer'.freeze
     SCHEMA_CDB_DATASERVICES_API = 'cdb_dataservices_client'.freeze
+    SCHEMA_COMMON_DATA = Cartodb::config[:fdw]['remote_schema'].freeze
 
     def initialize(user)
       @user = user
@@ -21,7 +22,8 @@ module Carto
     def self.build_search_path(user_schema, quote_user_schema = true)
       # TODO Add SCHEMA_CDB_GEOCODER when we open the geocoder API to all the people
       quote_char = quote_user_schema ? "\"" : ""
-      "#{quote_char}#{user_schema}#{quote_char}, #{SCHEMA_CARTODB}, #{SCHEMA_CDB_DATASERVICES_API}, #{SCHEMA_PUBLIC}"
+      # Bloomberg - automatically add the common data user to search path
+      "#{quote_char}#{user_schema}#{quote_char}, #{SCHEMA_CARTODB}, #{SCHEMA_CDB_DATASERVICES_API}, \"#{SCHEMA_COMMON_DATA}\", #{SCHEMA_PUBLIC}"
     end
 
     def public_user_roles

--- a/spec/models/carto/user_service_spec.rb
+++ b/spec/models/carto/user_service_spec.rb
@@ -69,7 +69,7 @@ describe Carto::UserService do
   end
 
   it "Tests search_path correctly set" do
-    expected_returned_normal_search_path = { search_path: "#{@user.database_schema}, cartodb, cdb_dataservices_client, public" }
+    expected_returned_normal_search_path = { search_path: "#{@user.database_schema}, cartodb, cdb_dataservices_client, \"#{Cartodb.config[:common_data]['username']}\", public" }
 
     @normal_search_path = nil
     @normal_search_path_new = nil


### PR DESCRIPTION
::User search_path was updated to include the common data user's schema in https://github.com/bloomberg/cartodb/blob/b6115008ed89a308dc56674239ca2ddd92dcb59f/app/models/user/db_service.rb#L198.  Updated Carto::User to match.