### PR TITLE
Updates overlay to only allow unique header type to match upstream

### DIFF
--- a/app/models/carto/overlay.rb
+++ b/app/models/carto/overlay.rb
@@ -20,7 +20,7 @@ module Carto
 
     # There can be at most one of this types per visualization
     UNIQUE_TYPES = [
-      'search', 'layer_selector', 'share', 'zoom', 'logo', 'loader', 'fullscreen', 'inset_map'
+      'header', 'search', 'layer_selector', 'share', 'zoom', 'logo', 'loader', 'fullscreen', 'inset_map'
     ].freeze
 
     BUILDER_COMPATIBLE_TYPES = ['search', 'layer_selector', 'share', 'fullscreen', 'loader', 'logo', 'zoom'].freeze

--- a/spec/requests/carto/api/overlays_controller_spec.rb
+++ b/spec/requests/carto/api/overlays_controller_spec.rb
@@ -38,7 +38,9 @@ describe Carto::Api::OverlaysController do
       existing_overlay_ids = []
       get_json overlays_url(params) do |response|
         response.status.should be_success
-        response.body.count.should eq 5 # Newly created overlays have this amount of layers
+        # The search overlay is hidden behind the bbg_pro_ui feature flag in Bloomberg
+        # Therefore this value is one lower than the carto upstream unit tests
+        response.body.count.should eq 4 # Newly created overlays have this amount of layers
         existing_overlay_ids = response.body.map { |overlay| overlay['id'] }
       end
 


### PR DESCRIPTION
Changed to match upstream carto which allows only one 'header' overlay per visualization.   

Initial tests show this is working fine on merge code.  Adding @tylerparsons to review since header overlays are important to news profile.  