### PR TITLE
Rdsimaps3165 fix unit test twitter

### DIFF
--- a/services/datasources/lib/datasources/search/twitter.rb
+++ b/services/datasources/lib/datasources/search/twitter.rb
@@ -458,7 +458,7 @@ module CartoDB
             timezoned_date += timezone*60
 
             # Gnip doesn't allows searches "in the future"
-            date = timezoned_date >= (Time.now - TIMEZONE_THRESHOLD).utc ? nil : timezoned_date.strftime("%Y%m%d%H%M")
+            date = timezoned_date >= (Time.now.utc - TIMEZONE_THRESHOLD).utc ? nil : timezoned_date.strftime("%Y%m%d%H%M")
           end
 
           date

--- a/services/datasources/lib/datasources/search/twitter.rb
+++ b/services/datasources/lib/datasources/search/twitter.rb
@@ -458,7 +458,7 @@ module CartoDB
             timezoned_date += timezone*60
 
             # Gnip doesn't allows searches "in the future"
-            date = timezoned_date >= (Time.now.utc - TIMEZONE_THRESHOLD).utc ? nil : timezoned_date.strftime("%Y%m%d%H%M")
+            date = timezoned_date >= (Time.now - TIMEZONE_THRESHOLD).utc ? nil : timezoned_date.strftime("%Y%m%d%H%M")
           end
 
           date

--- a/services/datasources/spec/unit/twitter_spec.rb
+++ b/services/datasources/spec/unit/twitter_spec.rb
@@ -141,7 +141,7 @@ describe Search::Twitter do
       }.to raise_error ParameterError
 
 
-      current_time = Time.now
+      current_time = Time.now.utc
       output = twitter_datasource.send :build_date_from_fields, {
         dates: {
           toDate:   current_time.strftime("%Y-%m-%d"),


### PR DESCRIPTION
Twitter spec assumes the time is sent as UTC.  However the system timezone is used in 'Time.now'.  Therefore force the timezone to be UTC.