### PR TITLE
Fix copy of export flags/category on library dataset import

### DIFF
--- a/app/models/table/user_table.rb
+++ b/app/models/table/user_table.rb
@@ -381,7 +381,10 @@ class UserTable < Sequel::Model
       tags:         (tags.split(',') if tags),
       privacy:      UserTable::PRIVACY_VALUES_TO_TEXTS[default_privacy_value],
       user_id:      user.id,
-      kind:         kind
+      kind:         kind,
+      exportable:   esv.nil? ? true : esv.exportable,
+      export_geom:  esv.nil? ? true : esv.export_geom,
+      category:     esv.nil? ? nil : esv.category
     )
 
     member.store


### PR DESCRIPTION
This ensures that the `exportable`, `export_geom` and `category` columns on the canonical table visualization record for a user match those of the library dataset from which it is copied.

This ensures that dataset export is blocked according to library dataset level flags, and also that datasets are correctly displayed within the category tree in the data library.

The issue was introduced when the logic for copying these fields was moved from the `Table` model to the `UserTable` model and the copying of these fields was not added to the new function.