### PR TITLE
Fixes url substitution for s3_proxy

### DIFF
--- a/app/models/carto/visualization_export.rb
+++ b/app/models/carto/visualization_export.rb
@@ -35,7 +35,7 @@ module Carto
        # Change the base url to match the proxy
        https_pos = uri.index('https')
        prefix = "http#{https_pos ? 's' : ''}://"
-       rv = uri.gsub(/^https?:\/\/[\w\.\:]+\//, '')
+       rv = uri.gsub(/^https?:\/\/[\w\.\-\:]+\//, '')
        rv = prefix + s3_proxy + '/' + rv
        # Remove any query parameters (items after '?')
        pos = rv.index('?')


### PR DESCRIPTION
Certain urls utilize a '-' character.  Updated regular expression to accommodate this.