### PR TITLE
Create new load_functions_bbg rake task to only load cartodb extensio…

### DIFF
--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -178,7 +178,8 @@ module CartoDB
       # Cartodb functions
       def load_cartodb_functions(statement_timeout = nil,
                                  cdb_extension_target_version = nil,
-                                 load_cartodb_extension = true)
+                                 load_cartodb_extension = true,
+                                 rebuild_quota = true)
         add_python
 
         # Install dependencies of cartodb extension
@@ -204,9 +205,11 @@ module CartoDB
 
         if load_cartodb_extension
           upgrade_cartodb_postgres_extension(statement_timeout, cdb_extension_target_version)
-          rebuild_quota_trigger
         end
 
+        if rebuild_quota
+          rebuild_quota_trigger
+        end
       end
 
       def rebuild_quota_trigger

--- a/app/models/user/db_service.rb
+++ b/app/models/user/db_service.rb
@@ -204,9 +204,9 @@ module CartoDB
 
         if load_cartodb_extension
           upgrade_cartodb_postgres_extension(statement_timeout, cdb_extension_target_version)
+          rebuild_quota_trigger
         end
 
-        rebuild_quota_trigger
       end
 
       def rebuild_quota_trigger

--- a/lib/tasks/db_maintenance.rake
+++ b/lib/tasks/db_maintenance.rake
@@ -234,7 +234,8 @@ namespace :cartodb do
         count = ::User.where(database_host: database_host).count
       end
       execute_on_users_with_index(task_name, Proc.new { |user, i|
-        begin log(sprintf("Trying on %-#{20}s %-#{20}s (%-#{4}s/%-#{4}s)...", user.username, user.database_name, i+1, count), task_name, database_host) # Only load cartodb extensions once per database, i.e. for dedicated users and org owners
+        begin
+          log(sprintf("Trying on %-#{20}s %-#{20}s (%-#{4}s/%-#{4}s)...", user.username, user.database_name, i+1, count), task_name, database_host) # Only load cartodb extensions once per database, i.e. for dedicated users and org owners
           # Only load cartodb extensions once per database, i.e. for dedicated users and org owners
           load_cartodb_extension = user.account_type == '[DEDICATED]' || user.organization_owner?
           if load_cartodb_extension

--- a/lib/tasks/db_maintenance.rake
+++ b/lib/tasks/db_maintenance.rake
@@ -235,7 +235,12 @@ namespace :cartodb do
       end
       execute_on_users_with_index(task_name, Proc.new { |user, i|
         begin log(sprintf("Trying on %-#{20}s %-#{20}s (%-#{4}s/%-#{4}s)...", user.username, user.database_name, i+1, count), task_name, database_host) # Only load cartodb extensions once per database, i.e. for dedicated users and org owners
-          user.db_service.load_cartodb_functions(statement_timeout, extension_version)
+          # Only load cartodb extensions once per database, i.e. for dedicated users and org owners
+          load_cartodb_extension = user.account_type == '[DEDICATED]' || user.organization_owner?
+          if load_cartodb_extension
+            log(sprintf("Loading cartodb extension on %-#{20}s %-#{20}s (%-#{4}s/%-#{4}s)...", user.username, user.database_name, i+1, count), task_name, database_host)
+          end
+          user.db_service.load_cartodb_functions(statement_timeout, extension_version, load_cartodb_extension)
           log(sprintf("OK %-#{20}s %-#{20}s (%-#{4}s/%-#{4}s)", user.username, user.database_name, i+1, count), task_name, database_host)
           sleep(sleep)
         rescue => e
@@ -274,9 +279,9 @@ namespace :cartodb do
           # Only load cartodb extensions once per database, i.e. for dedicated users and org owners
           load_cartodb_extension = user.account_type == '[DEDICATED]' || user.organization_owner?
           if load_cartodb_extension
-            log(sprintf("Loading cartodb extension on %-#{20}s %-#{20}s (%-#{4}s/%-#{4}s)...", user.username, user.database_name, i+1, count), task_name, database_host)
+            log(sprintf("Loading cartodb extension and rebuild quota on %-#{20}s %-#{20}s (%-#{4}s/%-#{4}s)...", user.username, user.database_name, i+1, count), task_name, database_host)
           end
-          user.db_service.load_cartodb_functions(statement_timeout, extension_version, load_cartodb_extension)
+          user.db_service.load_cartodb_functions(statement_timeout, extension_version, load_cartodb_extension, load_cartodb_extension)
           log(sprintf("OK %-#{20}s %-#{20}s (%-#{4}s/%-#{4}s)", user.username, user.database_name, i+1, count), task_name, database_host)
           sleep(sleep)
         rescue => e

--- a/lib/tasks/db_maintenance.rake
+++ b/lib/tasks/db_maintenance.rake
@@ -234,6 +234,41 @@ namespace :cartodb do
         count = ::User.where(database_host: database_host).count
       end
       execute_on_users_with_index(task_name, Proc.new { |user, i|
+        begin log(sprintf("Trying on %-#{20}s %-#{20}s (%-#{4}s/%-#{4}s)...", user.username, user.database_name, i+1, count), task_name, database_host) # Only load cartodb extensions once per database, i.e. for dedicated users and org owners
+          user.db_service.load_cartodb_functions(statement_timeout, extension_version)
+          log(sprintf("OK %-#{20}s %-#{20}s (%-#{4}s/%-#{4}s)", user.username, user.database_name, i+1, count), task_name, database_host)
+          sleep(sleep)
+        rescue => e
+          log(sprintf("FAIL %-#{20}s (%-#{4}s/%-#{4}s) #{e.message}", user.username, i+1, count), task_name, database_host)
+          puts "FAIL:#{i} #{e.message}"
+        end
+      }, threads, thread_sleep, database_host)
+    end
+
+    desc 'Install/upgrade CARTODB SQL functions - only organization owners for Bloomberg merge code release'
+    task :load_functions_bbg, [:database_host, :version, :num_threads, :thread_sleep, :sleep, :statement_timeout] => :environment do |task_name, args|
+      # Send this as string, not as number
+      extension_version = args[:version].blank? ? nil : args[:version]
+      database_host = args[:database_host].blank? ? nil : args[:database_host]
+      threads = args[:num_threads].blank? ? 1 : args[:num_threads].to_i
+      thread_sleep = args[:thread_sleep].blank? ? 0.25 : args[:thread_sleep].to_f
+      sleep = args[:sleep].blank? ? 1 : args[:sleep].to_i
+      statement_timeout = args[:statement_timeout].blank? ? 180000 : args[:statement_timeout]
+
+      puts "Running extension update with following config:"
+      puts "extension_version: #{extension_version.nil? ? 'UNSPECIFIED/LATEST' : extension_version}"
+      puts "database_host: #{database_host.nil? ? 'ALL' : database_host}"
+      puts "threads: #{threads}"
+      puts "thread_sleep: #{thread_sleep}"
+      puts "sleep: #{sleep}"
+      puts "statement_timeout: #{statement_timeout}"
+
+      if database_host.nil?
+        count = ::User.count
+      else
+        count = ::User.where(database_host: database_host).count
+      end
+      execute_on_users_with_index(task_name, Proc.new { |user, i|
         begin
           log(sprintf("Trying on %-#{20}s %-#{20}s (%-#{4}s/%-#{4}s)...", user.username, user.database_name, i+1, count), task_name, database_host)
           # Only load cartodb extensions once per database, i.e. for dedicated users and org owners

--- a/lib/tasks/db_maintenance.rake
+++ b/lib/tasks/db_maintenance.rake
@@ -278,11 +278,7 @@ namespace :cartodb do
         begin
           log(sprintf("Trying on %-#{20}s %-#{20}s (%-#{4}s/%-#{4}s)...", user.username, user.database_name, i+1, count), task_name, database_host)
           # Only load cartodb extensions once per database, i.e. for dedicated users and org owners
-          load_cartodb_extension = user.account_type == '[DEDICATED]' || user.organization_owner?
-          if load_cartodb_extension
-            log(sprintf("Loading cartodb extension and rebuild quota on %-#{20}s %-#{20}s (%-#{4}s/%-#{4}s)...", user.username, user.database_name, i+1, count), task_name, database_host)
-          end
-          user.db_service.load_cartodb_functions(statement_timeout, extension_version, load_cartodb_extension, load_cartodb_extension)
+          user.db_service.load_cartodb_functions(statement_timeout, extension_version)
           log(sprintf("OK %-#{20}s %-#{20}s (%-#{4}s/%-#{4}s)", user.username, user.database_name, i+1, count), task_name, database_host)
           sleep(sleep)
         rescue => e

--- a/lib/tasks/db_maintenance.rake
+++ b/lib/tasks/db_maintenance.rake
@@ -235,7 +235,7 @@ namespace :cartodb do
       end
       execute_on_users_with_index(task_name, Proc.new { |user, i|
         begin
-          log(sprintf("Trying on %-#{20}s %-#{20}s (%-#{4}s/%-#{4}s)...", user.username, user.database_name, i+1, count), task_name, database_host) # Only load cartodb extensions once per database, i.e. for dedicated users and org owners
+          log(sprintf("Trying on %-#{20}s %-#{20}s (%-#{4}s/%-#{4}s)...", user.username, user.database_name, i+1, count), task_name, database_host)
           # Only load cartodb extensions once per database, i.e. for dedicated users and org owners
           load_cartodb_extension = user.account_type == '[DEDICATED]' || user.organization_owner?
           if load_cartodb_extension


### PR DESCRIPTION
…ns and quota updates on dedicated users and organization owners

During migration the following will need to be run:

bundle exec rake cartodb:db:load_functions_bbg
bundle exec rake cartodb:db:load_functions