### PR TITLE
Enforce map legends flag is true by default

### DIFF
--- a/app/models/carto/map.rb
+++ b/app/models/carto/map.rb
@@ -211,6 +211,9 @@ class Carto::Map < ActiveRecord::Base
     options[:legends] = (legends || true) if options[:legends].nil?
     options[:scrollwheel] = (scrollwheel || true) if options[:scrollwheel].nil?
 
+    # Sync legends property with options flag for backward compatibility
+    self.legends = options[:legends]
+
     options
   end
 

--- a/app/models/map.rb
+++ b/app/models/map.rb
@@ -70,6 +70,10 @@ class Map < Sequel::Model
                 # Flag to detect if being destroyed by whom so invalidate_vizjson_varnish_cache skips it
                 :being_destroyed_by_vis_id
 
+  def after_initialize
+    set_defaults
+  end
+
   def before_save
     super
     self.updated_at = Time.now
@@ -263,5 +267,10 @@ class Map < Sequel::Model
 
   def table_name
     tables.first.nil? ? nil : tables.first.name
+  end
+
+  def set_defaults
+    # Protect against nil boolean flags
+    self.legends = (self.legends || true) if self.legends.nil?
   end
 end


### PR DESCRIPTION
# Problem

When saving a copy of a sample map or opening a dataset in a map from the library, the legends of datasets on the map are hidden by default.  This is not the intended or current production behavior, rather maps should always display legends, if any, by default.

This issue is caused by the `legends` property of the map models being incorrectly initialized.  Instead of being `true` by default, which is the default value of the column in the database, the property is set to `nil` and interpreted as falsey by the UI.

# Solution

When initializing any map model, namely `Map` and `Carto::Map`, the `legends` property should be set to `true` if it is `nil`.  This ensures consistent behavior with the current blp_dev and with the database default.

# Caveat

It appears that in the carto upstream, the `legends` property has been deprecated in favor of a flag in the `options` hash.  Unfortunately, this change was not fully merged onto our branch and thus we still depend on this `legends` property in some places.

I've tested these changes with all map creation workflows, and they seem to be working.  I've also identified usages of legends determined that it's largely unused in the editor.  While ultimately we should migrate away from this flag as in the upstream, this issue does require a hotfix.

@gfiorav what are your thoughts? I notice you were one of the last to edit the `Carto::Map` file and made the same change for `options[:legends]`.