### PR TITLE
Preserve layer options interactivity in named maps

### DIFF
--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -151,7 +151,7 @@ module Carto
 
         options[:sql_wrap] = layer_options[:sql_wrap] || layer_options[:query_wrapper]
 
-        attributes, interactivity = attributes_and_interactivity(layer.infowindow, layer.tooltip)
+        attributes, interactivity = attributes_and_interactivity(layer, layer_options)
 
         options[:attributes] = attributes if attributes.present?
         options[:interactivity] = interactivity if interactivity.present?
@@ -163,7 +163,9 @@ module Carto
         "SELECT * FROM (#{sql}) AS wrapped_query WHERE <%= layer#{index} %>=1"
       end
 
-      def attributes_and_interactivity(layer_infowindow, layer_tooltip)
+      def attributes_and_interactivity(layer, layer_options)
+        layer_infowindow = layer.infowindow
+        layer_tooltip = layer.tooltip
         click_fields = layer_infowindow['fields'] if layer_infowindow
         hover_fields = layer_tooltip['fields'] if layer_tooltip
 
@@ -171,7 +173,7 @@ module Carto
         attributes = {}
 
         if hover_fields.present?
-          interactivity << hover_fields.map { |hover_field| hover_field.fetch('name') }
+          interactivity = hover_fields.map { |hover_field| hover_field.fetch('name') }
         end
 
         if click_fields.present?
@@ -183,7 +185,11 @@ module Carto
           }
         end
 
-        [attributes, interactivity.join(',')]
+        if layer_options[:interactivity]
+          interactivity = interactivity & layer_options[:interactivity].split(',')
+        end
+
+        [attributes, interactivity.uniq.join(',')]
       end
 
       def dataviews

--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -151,7 +151,7 @@ module Carto
 
         options[:sql_wrap] = layer_options[:sql_wrap] || layer_options[:query_wrapper]
 
-        attributes, interactivity = attributes_and_interactivity(layer, layer_options)
+        attributes, interactivity = attributes_and_interactivity(layer.infowindow, layer.tooltip)
 
         options[:attributes] = attributes if attributes.present?
         options[:interactivity] = interactivity if interactivity.present?
@@ -163,9 +163,7 @@ module Carto
         "SELECT * FROM (#{sql}) AS wrapped_query WHERE <%= layer#{index} %>=1"
       end
 
-      def attributes_and_interactivity(layer, layer_options)
-        layer_infowindow = layer.infowindow
-        layer_tooltip = layer.tooltip
+      def attributes_and_interactivity(layer_infowindow, layer_tooltip)
         click_fields = layer_infowindow['fields'] if layer_infowindow
         hover_fields = layer_tooltip['fields'] if layer_tooltip
 
@@ -185,8 +183,8 @@ module Carto
           }
         end
 
-        if layer_options[:interactivity]
-          interactivity = interactivity & layer_options[:interactivity].split(',')
+        if interactivity.empty?
+          interactivity << 'cartodb_id'
         end
 
         [attributes, interactivity.uniq.join(',')]

--- a/lib/carto/named_maps/template.rb
+++ b/lib/carto/named_maps/template.rb
@@ -184,7 +184,7 @@ module Carto
         end
 
         if interactivity.empty?
-          interactivity << 'cartodb_id'
+          interactivity = ['cartodb_id']
         end
 
         [attributes, interactivity.uniq.join(',')]

--- a/spec/lib/carto/named_maps/template_spec.rb
+++ b/spec/lib/carto/named_maps/template_spec.rb
@@ -70,6 +70,37 @@ module Carto
             @template_hash[:layergroup][:layers].second[:id].should eq @carto_layer.id
           end
 
+          describe 'without tooltip or infowindow' do
+            before(:all) do
+              @carto_layer.tooltip = nil
+              @carto_layer.infowindow = nil
+              @carto_layer.save
+
+              @visualization.reload
+
+              template_hash = Carto::NamedMaps::Template.new(@visualization).to_hash
+              @layer_options_hash = template_hash[:layergroup][:layers].second[:options]
+            end
+
+            after(:all) do
+              @carto_layer.tooltip = nil
+              @carto_layer.infowindow = nil
+              @carto_layer.save
+
+              @visualization.reload
+              @layer_options_hash = nil
+            end
+
+            it 'should use cartodb_id as the default interactivity' do
+              @layer_options_hash[:interactivity].should_not be_nil
+              @layer_options_hash[:interactivity].should eq 'cartodb_id'
+            end
+
+            it 'should not contain attributes' do
+              @layer_options_hash[:attributes].should be_nil
+            end
+          end
+
           describe 'with popups' do
             let(:dummy_infowindow) do
               {


### PR DESCRIPTION
It looks like the `interactivity` property of named maps, which stores a list of all columns that a particular layer uses in it's click and hover tooltips, was not getting copied to redis when named maps were created or updated.  This change is to ensure the property is always copied on a create/update of a named map.

The cause of this seems to be a change in the schema of the `layers.options` object, which is a big json object created on the frontend when creating maps. What likely happened is that the carto builder introduced a schema change which was not replicated in our editor, and the old schema was no longer maintained by the backend.